### PR TITLE
Avalonia 12 standalone media player package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,45 @@ jobs:
       - name: Build solution (Release)
         run: dotnet build FFmpegVideoPlayer.Avalonia.sln -c Release --no-restore
 
+      - name: Test solution (Release)
+        run: dotnet test FFmpegVideoPlayer.Avalonia.sln -c Release --no-build --no-restore
+
       - name: Build example app (Release)
-        run: dotnet build examples/FFmpegVideoPlayerExample/FFmpegVideoPlayerExample.csproj -c Release --no-restore
+        run: dotnet build examples/FFmpegVideoPlayerExample/FFmpegVideoPlayerExample.csproj -c Release
+
+      - name: Pack standalone NuGet package
+        if: matrix.dotnet-version == '10.0.x'
+        run: dotnet pack Avalonia.FFmpegVideoPlayer.csproj -c Release -o artifacts/package
+
+      - name: Validate package in a clean consumer
+        if: matrix.dotnet-version == '10.0.x'
+        shell: bash
+        env:
+          NUGET_PACKAGES: ${{ runner.temp }}/ffmpeg-player-smoke-nuget
+        run: |
+          set -euo pipefail
+
+          package_dir="$GITHUB_WORKSPACE/artifacts/package"
+          consumer_dir="$RUNNER_TEMP/ffmpeg-player-package-smoke"
+          package_version="$(dotnet msbuild Avalonia.FFmpegVideoPlayer.csproj -nologo -getProperty:Version -p:Configuration=Release)"
+
+          dotnet new console --name PackageSmoke --framework net8.0 --output "$consumer_dir" --no-restore
+          dotnet new nugetconfig --output "$consumer_dir"
+          dotnet nuget add source "$package_dir" --name package-under-test --configfile "$consumer_dir/NuGet.Config"
+          dotnet add "$consumer_dir/PackageSmoke.csproj" package FFmpegVideoPlayer.Avalonia --version "$package_version" --no-restore
+
+          printf '%s\n' \
+            'using Avalonia.FFmpegVideoPlayer;' \
+            'using FFmpegVideoPlayer.Core;' \
+            'Console.WriteLine($"{typeof(VideoPlayerControl).Assembly.GetName().Name}|{typeof(FFmpegInitializer).Assembly.GetName().Name}");' \
+            > "$consumer_dir/Program.cs"
+
+          dotnet restore "$consumer_dir/PackageSmoke.csproj" --configfile "$consumer_dir/NuGet.Config"
+          dotnet run --project "$consumer_dir/PackageSmoke.csproj" --configuration Release --no-restore
+
+      - name: Upload standalone package
+        if: matrix.dotnet-version == '10.0.x'
+        uses: actions/upload-artifact@v4
+        with:
+          name: FFmpegVideoPlayer.Avalonia
+          path: artifacts/package/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
 
           dotnet new console --name PackageSmoke --framework net8.0 --output "$consumer_dir" --no-restore
           dotnet new nugetconfig --output "$consumer_dir"
-          dotnet nuget add source "$package_dir" --name package-under-test --configfile "$consumer_dir/NuGet.Config"
+          nuget_config="$(find "$consumer_dir" -maxdepth 1 -iname 'nuget.config' -print -quit)"
+          test -n "$nuget_config"
+          dotnet nuget add source "$package_dir" --name package-under-test --configfile "$nuget_config"
           dotnet add "$consumer_dir/PackageSmoke.csproj" package FFmpegVideoPlayer.Avalonia --version "$package_version" --no-restore
 
           printf '%s\n' \
@@ -62,7 +64,7 @@ jobs:
             'Console.WriteLine($"{typeof(VideoPlayerControl).Assembly.GetName().Name}|{typeof(FFmpegInitializer).Assembly.GetName().Name}");' \
             > "$consumer_dir/Program.cs"
 
-          dotnet restore "$consumer_dir/PackageSmoke.csproj" --configfile "$consumer_dir/NuGet.Config"
+          dotnet restore "$consumer_dir/PackageSmoke.csproj" --configfile "$nuget_config"
           dotnet run --project "$consumer_dir/PackageSmoke.csproj" --configuration Release --no-restore
 
       - name: Upload standalone package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish NuGet package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Read version from release tag
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag '$GITHUB_REF_NAME' is not a package version." >&2
+            exit 1
+          fi
+          echo "PACKAGE_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Restore, build and test
+        run: |
+          dotnet restore FFmpegVideoPlayer.Avalonia.sln
+          dotnet build FFmpegVideoPlayer.Avalonia.sln -c Release --no-restore
+          dotnet test FFmpegVideoPlayer.Avalonia.sln -c Release --no-build --no-restore
+
+      - name: Pack the standalone package
+        run: dotnet pack Avalonia.FFmpegVideoPlayer.csproj -c Release -p:Version=${{ env.PACKAGE_VERSION }} -o artifacts/package
+
+      - name: Attach package to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" artifacts/package/*.nupkg --clobber
+
+      - name: Publish to NuGet.org
+        run: dotnet nuget push "artifacts/package/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key "${{ secrets.NUGET_API_KEY }}" --skip-duplicate

--- a/Avalonia.FFmpegVideoPlayer.csproj
+++ b/Avalonia.FFmpegVideoPlayer.csproj
@@ -10,12 +10,12 @@
     <PackageId>FFmpegVideoPlayer.Avalonia</PackageId>
     <AssemblyName>Avalonia.FFmpegVideoPlayer</AssemblyName>
     <RootNamespace>Avalonia.FFmpegVideoPlayer</RootNamespace>
-    <Version>2.9.0</Version>
+    <IsPackable>true</IsPackable>
     <Authors>jojomondag</Authors>
     <Company>jojomondag</Company>
-    <Description>FFmpeg media player for Avalonia UI with video and audio-only playback. Windows FFmpeg binaries bundled; macOS and Linux users get auto-install via Homebrew/apt/dnf/pacman on first run.</Description>
-    <PackageReleaseNotes>v2.9.0: Adds audio-only playback support in VideoPlayerControl and fixes OpenAL audio queue loss that could make audio end early or sound too fast. v2.8.1: Fix #4 — rebuilt against Avalonia 12.0.1 to resolve ReflectionBindingExtension.ProvideValue MissingMethodException in Avalonia 12.x apps. v2.8.0: Close #1 — Linux auto-install via apt/dnf/pacman (with sudo -n), matching the existing macOS Homebrew flow. macOS x64 (Intel) Homebrew was already supported. v2.7.1: Fix #3 — frame-accurate slider seeking. v2.7.0: Fix #2 — macOS NotSupportedException at avformat_open_input (bundled osx-arm64 dylibs removed; initializer validates load and falls back). v2.6.3: OpenAL default audio.</PackageReleaseNotes>
-    <PackageTags>avalonia;ffmpeg;video;audio;player;media;cross-platform;arm64;self-contained</PackageTags>
+    <Description>Standalone FFmpeg media player for Avalonia 12. Bundles FFmpeg for Windows x64; other OS/architectures use a compatible system FFmpeg installation.</Description>
+    <PackageReleaseNotes>v3.0.0: Targets Avalonia 12.1, ships as one standalone package, adds typed and asynchronous media sources, built-in YouTube resolution, bounded/cancellable network I/O, lifecycle state, and structured media errors.</PackageReleaseNotes>
+    <PackageTags>avalonia;ffmpeg;video;audio;player;media;cross-platform;windows-x64;system-ffmpeg</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jojomondag/FFmpegVideoPlayer.Avalonia</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jojomondag/FFmpegVideoPlayer.Avalonia</RepositoryUrl>
@@ -27,6 +27,7 @@
     
     <!-- Prevent duplicate assembly info generation -->
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);PackProjectReferenceOutputs</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <!-- Exclude examples folder, Core files, and Audio.OpenTK from compilation -->
@@ -35,6 +36,10 @@
     <AvaloniaXaml Remove="examples/**/*.axaml" />
     <AvaloniaResource Remove="examples/**/*" />
     <None Remove="examples/**/*" />
+    <Compile Remove="tests/**/*.cs" />
+    <AvaloniaXaml Remove="tests/**/*.axaml" />
+    <AvaloniaResource Remove="tests/**/*" />
+    <None Remove="tests/**/*" />
     <!-- Remove Core files - they're now in the Core project -->
     <Compile Remove="AudioPlayer.cs" />
     <Compile Remove="FFmpegInitializer.cs" />
@@ -50,19 +55,50 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia" Version="[$(AvaloniaVersion),13.0.0)" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="8.0.0.1" />
+    <PackageReference Include="YoutubeExplode" Version="6.6.0" />
+    <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />
+    <PackageReference Include="OpenAL.Soft" Version="1.23.1" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Core + OpenTK audio (OpenAL) so playback has sound by default; override via AudioPlayerFactory property if needed -->
   <ItemGroup>
-    <ProjectReference Include="FFmpegVideoPlayer.Core\FFmpegVideoPlayer.Core.csproj" />
-    <ProjectReference Include="FFmpegVideoPlayer.Audio.OpenTK\FFmpegVideoPlayer.Audio.OpenTK.csproj" />
+    <ProjectReference Include="FFmpegVideoPlayer.Core\FFmpegVideoPlayer.Core.csproj" PrivateAssets="all" />
+    <ProjectReference Include="FFmpegVideoPlayer.Audio.OpenTK\FFmpegVideoPlayer.Audio.OpenTK.csproj" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- Include README and images in package -->
+  <!-- Include documentation, third-party license texts, and images in package -->
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="" />
+    <None Include="THIRD-PARTY-NOTICES.md" Pack="true" PackagePath="" />
+    <None Include="LICENSES/GPL-3.0.txt" Pack="true" PackagePath="LICENSES/" />
+    <None Include="LICENSES/LGPL-2.0-or-later.txt" Pack="true" PackagePath="LICENSES/" />
+    <None Include="LICENSES/LGPL-3.0-or-later.txt" Pack="true" PackagePath="LICENSES/" />
     <None Include="images/Preview1.png" Pack="true" PackagePath="images/" />
+  </ItemGroup>
+
+  <!-- OpenAL.Soft stores release binaries below an extra Release folder, so include
+       them explicitly at conventional runtime paths in the single public package. -->
+  <ItemGroup>
+    <None Include="$(PkgOpenAL_Soft)\runtimes\win-x64\native\Release\OpenAL32.dll"
+          Pack="true" PackagePath="runtimes/win-x64/native/"
+          Link="runtimes/win-x64/native/OpenAL32.dll"
+          TargetPath="runtimes/win-x64/native/OpenAL32.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('$(PkgOpenAL_Soft)\runtimes\win-x64\native\Release\OpenAL32.dll')" />
+    <None Include="$(PkgOpenAL_Soft)\runtimes\win-x86\native\Release\OpenAL32.dll"
+          Pack="true" PackagePath="runtimes/win-x86/native/"
+          Link="runtimes/win-x86/native/OpenAL32.dll"
+          TargetPath="runtimes/win-x86/native/OpenAL32.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('$(PkgOpenAL_Soft)\runtimes\win-x86\native\Release\OpenAL32.dll')" />
+    <None Include="$(PkgOpenAL_Soft)\runtimes\win-arm64\native\Release\OpenAL32.dll"
+          Pack="true" PackagePath="runtimes/win-arm64/native/"
+          Link="runtimes/win-arm64/native/OpenAL32.dll"
+          TargetPath="runtimes/win-arm64/native/OpenAL32.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('$(PkgOpenAL_Soft)\runtimes\win-arm64\native\Release\OpenAL32.dll')" />
   </ItemGroup>
 
   <!-- 
@@ -113,8 +149,23 @@
       <NativeRuntimeFiles Include="runtimes/**/*.*" Exclude="runtimes/README.md" />
     </ItemGroup>
     <Copy SourceFiles="@(NativeRuntimeFiles)"
-          DestinationFiles="@(NativeRuntimeFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(NativeRuntimeFiles->'$(OutDir)runtimes\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           Condition="'@(NativeRuntimeFiles)' != ''" />
+  </Target>
+
+  <!-- Core and Audio stay implementation projects. Their assemblies are embedded in
+       FFmpegVideoPlayer.Avalonia instead of becoming separate NuGet dependencies. -->
+  <Target Name="PackProjectReferenceOutputs"
+          DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <_EmbeddedProjectAssembly
+          Include="@(ReferenceCopyLocalPaths)"
+          Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+      <BuildOutputInPackage Include="@(_EmbeddedProjectAssembly)">
+        <FinalOutputPath>%(_EmbeddedProjectAssembly.FullPath)</FinalOutputPath>
+        <TargetPath>%(_EmbeddedProjectAssembly.Filename)%(_EmbeddedProjectAssembly.Extension)</TargetPath>
+      </BuildOutputInPackage>
+    </ItemGroup>
   </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <Version>3.0.0</Version>
+    <AvaloniaVersion>12.1.0</AvaloniaVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/FFmpegVideoPlayer.Audio.OpenTK/AudioPlayerFactory.cs
+++ b/FFmpegVideoPlayer.Audio.OpenTK/AudioPlayerFactory.cs
@@ -1,6 +1,4 @@
 using FFmpegVideoPlayer.Core;
-using OpenTK.Audio.OpenAL;
-
 namespace FFmpegVideoPlayer.Audio.OpenTK;
 
 /// <summary>
@@ -16,22 +14,7 @@ public static class AudioPlayerFactory
     {
         try
         {
-            var device = ALC.OpenDevice(null);
-            if (device == ALDevice.Null)
-            {
-                return false;
-            }
-            
-            var context = ALC.CreateContext(device, (int[]?)null);
-            if (context == ALContext.Null)
-            {
-                ALC.CloseDevice(device);
-                return false;
-            }
-            
-            ALC.MakeContextCurrent(context);
-            ALC.DestroyContext(context);
-            ALC.CloseDevice(device);
+            using var probe = new OpenTKAudioPlayer(8_000, 1);
             return true;
         }
         catch
@@ -52,15 +35,6 @@ public static class AudioPlayerFactory
     /// </remarks>
     public static IAudioPlayer? Create(int sampleRate, int channels)
     {
-        // First check if OpenAL is available
-        if (!IsOpenALAvailable())
-        {
-            System.Diagnostics.Debug.WriteLine($"[AudioPlayerFactory] OpenAL is not available on this system.");
-            System.Diagnostics.Debug.WriteLine($"[AudioPlayerFactory] On Windows, ensure OpenAL Soft is installed or openal32.dll is available.");
-            System.Diagnostics.Debug.WriteLine($"[AudioPlayerFactory] Download from: https://www.openal-soft.org/downloads/");
-            return null;
-        }
-        
         try
         {
             return new OpenTKAudioPlayer(sampleRate, channels);

--- a/FFmpegVideoPlayer.Audio.OpenTK/FFmpegVideoPlayer.Audio.OpenTK.csproj
+++ b/FFmpegVideoPlayer.Audio.OpenTK/FFmpegVideoPlayer.Audio.OpenTK.csproj
@@ -2,16 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
     
     <!-- NuGet Package Properties -->
     <PackageId>FFmpegVideoPlayer.Audio.OpenTK</PackageId>
     <AssemblyName>FFmpegVideoPlayer.Audio.OpenTK</AssemblyName>
     <RootNamespace>FFmpegVideoPlayer.Audio.OpenTK</RootNamespace>
-    <Version>2.1.8</Version>
     <Authors>jojomondag</Authors>
     <Company>jojomondag</Company>
     <Description>OpenTK-based audio implementation for FFmpegVideoPlayer.Core. Provides audio playback using OpenAL.</Description>
@@ -30,29 +27,11 @@
     <ProjectReference Include="..\FFmpegVideoPlayer.Core\FFmpegVideoPlayer.Core.csproj" />
     
     <!-- OpenTK for audio playback - cross-platform -->
-    <PackageReference Include="OpenTK" Version="4.8.2" />
+    <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />
     
     <!-- OpenAL Soft native libraries for Windows -->
-    <PackageReference Include="OpenAL.Soft" Version="1.19.1" GeneratePathProperty="true" />
+    <PackageReference Include="OpenAL.Soft" Version="1.23.1" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
   
-  <!-- Include OpenAL native libraries as content files that copy to output -->
-  <ItemGroup>
-    <Content Include="$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x64\native\OpenAL32.dll" 
-             Condition="Exists('$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x64\native\OpenAL32.dll')">
-      <Link>runtimes\win-x64\native\OpenAL32.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>true</Pack>
-      <PackagePath>runtimes\win-x64\native\</PackagePath>
-    </Content>
-    <Content Include="$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x86\native\OpenAL32.dll"
-             Condition="Exists('$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x86\native\OpenAL32.dll')">
-      <Link>runtimes\win-x86\native\OpenAL32.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>true</Pack>
-      <PackagePath>runtimes\win-x86\native\</PackagePath>
-    </Content>
-  </ItemGroup>
-
 </Project>
 

--- a/FFmpegVideoPlayer.Audio.OpenTK/OpenTKAudioPlayer.cs
+++ b/FFmpegVideoPlayer.Audio.OpenTK/OpenTKAudioPlayer.cs
@@ -1,540 +1,770 @@
-using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
 using FFmpegVideoPlayer.Core;
 using OpenTK.Audio.OpenAL;
 
 namespace FFmpegVideoPlayer.Audio.OpenTK;
 
 /// <summary>
-/// OpenTK-based audio player implementation using OpenAL for low-latency audio playback.
-/// Handles sample format conversion and buffer management.
+/// OpenAL audio backend with a single owner thread for every AL/ALC operation.
+/// PCM producers are backpressured by a bounded managed queue, while control
+/// operations are delivered to the owner thread as commands.
 /// </summary>
 public sealed class OpenTKAudioPlayer : IAudioPlayer
 {
+    private const int BufferCount = 16;
+    private const int SamplesPerPacket = 16_384;
+    private const int InitialBufferTarget = 4;
+    private const int InitialStartDelayMilliseconds = 75;
+    private const int MaximumPendingSeconds = 2;
+    private const int StartupTimeoutMilliseconds = 10_000;
+    private const int DisposeJoinTimeoutMilliseconds = 5_000;
+
     private readonly int _sampleRate;
     private readonly int _channels;
     private readonly int _inputChannels;
-    private readonly ALDevice _device;
-    private readonly ALContext _context;
-    private readonly int _source;
-    private readonly ConcurrentQueue<int> _availableBuffers;
-    private readonly ConcurrentQueue<float[]> _pendingSamples;
-    private readonly ConcurrentQueue<short[]> _pendingS16Samples;
-    private readonly Thread _audioThread;
-    private readonly CancellationTokenSource _cts;
-    private float _volume = 1.0f;
-    private bool _isPlaying;
-    private bool _isPaused;
-    private bool _isDisposed;
+    private readonly int _maximumPendingSamples;
     private readonly PlayerLogger _logger;
-    private long _totalSamplesPlayed = 0; // Track total samples played for sync
-    private long _totalSamplesQueued = 0; // Track total samples queued (for accurate sync)
-    private readonly object _syncLock = new();
+    private readonly ConcurrentQueue<AudioCommand> _commands = new();
+    private readonly AutoResetEvent _wake = new(false);
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly TaskCompletionSource<Exception?> _startup =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _pcmLock = new();
+    private readonly Queue<PcmPacket> _pendingPcm = new();
+    private readonly Thread _audioThread;
 
-    private const int BufferCount = 16;
-    private const int SamplesPerBuffer = 16384; // Increased buffer size for smoother playback
+    // These native handles and collections are accessed by the audio thread only.
+    private ALDevice _device = ALDevice.Null;
+    private ALContext _context = ALContext.Null;
+    private int _source;
+    private readonly Queue<int> _availableBuffers = new();
+    private readonly List<int> _allBuffers = new(BufferCount);
+    private readonly Dictionary<int, int> _bufferSampleCounts = new(BufferCount);
+    private long _playedSamples;
+    private bool _hasStartedOnce;
+    private bool _workerInputCompleted;
+    private long _firstQueuedTimestamp;
+
+    // Cross-thread state. Native state is sampled and published by the audio thread.
+    private int _generation;
+    private int _pendingSampleCount;
+    private int _inputCompleted;
+    private int _desiredPaused;
+    private int _disposeRequested;
+    private int _workerExited;
+    private int _isDrained = 1;
+    private int _volumeBits = BitConverter.SingleToInt32Bits(1.0f);
+    private long _cachedPlaybackTimeBits;
 
     public OpenTKAudioPlayer(int sampleRate, int channels)
     {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        if (channels <= 0)
+            throw new ArgumentOutOfRangeException(nameof(channels));
+
         _sampleRate = sampleRate;
         _inputChannels = channels;
-        _channels = Math.Min(channels, 2); // Output is limited to stereo
+        _channels = Math.Min(channels, 2);
+        _maximumPendingSamples = checked((int)Math.Min(
+            int.MaxValue,
+            Math.Max(SamplesPerPacket, (long)sampleRate * _channels * MaximumPendingSeconds)));
         _logger = new PlayerLogger();
-        
-        Debug.WriteLine($"[OpenTKAudioPlayer] Initializing: sampleRate={sampleRate}, inputChannels={channels}, outputChannels={_channels}");
-        _logger.Log("OpenTKAudioPlayer", "Initialize", new { SampleRate = sampleRate, InputChannels = channels, OutputChannels = _channels });
-        
-        // Initialize OpenAL
-        try
-        {
-            _device = ALC.OpenDevice(null);
-            if (_device == ALDevice.Null)
-            {
-                var errorMsg = "Failed to open audio device. OpenAL may not be available. " +
-                              "On Windows, ensure OpenAL Soft is installed or OpenTK native libraries are present.";
-                Debug.WriteLine($"[OpenTKAudioPlayer] {errorMsg}");
-                _logger.Log("OpenTKAudioPlayer", "OpenDeviceFailed", new { Error = errorMsg });
-                throw new InvalidOperationException(errorMsg);
-            }
-            
-            Debug.WriteLine($"[OpenTKAudioPlayer] Audio device opened successfully");
-            _logger.Log("OpenTKAudioPlayer", "OpenDeviceSuccess", null);
-        }
-        catch (DllNotFoundException ex)
-        {
-            var errorMsg = $"OpenAL native library not found: {ex.Message}. " +
-                          "On Windows, OpenTK requires OpenAL Soft (openal32.dll) to be available. " +
-                          "Ensure OpenTK native libraries are properly deployed or install OpenAL Soft.";
-            Debug.WriteLine($"[OpenTKAudioPlayer] {errorMsg}");
-            _logger.Log("OpenTKAudioPlayer", "OpenDeviceFailed", new { Error = errorMsg, Exception = ex.Message });
-            throw new InvalidOperationException(errorMsg, ex);
-        }
-        catch (Exception ex)
-        {
-            var errorMsg = $"Failed to initialize OpenAL: {ex.Message}";
-            Debug.WriteLine($"[OpenTKAudioPlayer] {errorMsg}");
-            _logger.Log("OpenTKAudioPlayer", "OpenDeviceFailed", new { Error = errorMsg, Exception = ex.Message });
-            throw new InvalidOperationException(errorMsg, ex);
-        }
 
-        _context = ALC.CreateContext(_device, (int[]?)null);
-        if (_context == ALContext.Null)
+        _logger.Log("OpenTKAudioPlayer", "Initialize", new
         {
-            var error = ALC.GetError(_device);
-            var errorMsg = $"Failed to create OpenAL context. Error: {error}";
-            Debug.WriteLine($"[OpenTKAudioPlayer] {errorMsg}");
-            throw new InvalidOperationException(errorMsg);
-        }
-        
-        ALC.MakeContextCurrent(_context);
-        var contextError = ALC.GetError(_device);
-        if (contextError != AlcError.NoError)
-        {
-            Debug.WriteLine($"[OpenTKAudioPlayer] Warning: ALC.MakeContextCurrent error: {contextError}");
-        }
+            SampleRate = sampleRate,
+            InputChannels = channels,
+            OutputChannels = _channels,
+            MaximumPendingSamples = _maximumPendingSamples
+        });
 
-        // Create source
-        _source = AL.GenSource();
-        var sourceError = AL.GetError();
-        if (sourceError != ALError.NoError)
-        {
-            Debug.WriteLine($"[OpenTKAudioPlayer] Warning: AL.GenSource error: {sourceError}");
-        }
-        
-        AL.Source(_source, ALSourcef.Gain, _volume);
-        var gainError = AL.GetError();
-        if (gainError != ALError.NoError)
-        {
-            Debug.WriteLine($"[OpenTKAudioPlayer] Warning: AL.Source(Gain) error: {gainError}");
-        }
-
-        // Create buffers
-        _availableBuffers = new ConcurrentQueue<int>();
-        for (int i = 0; i < BufferCount; i++)
-        {
-            _availableBuffers.Enqueue(AL.GenBuffer());
-        }
-
-        _pendingSamples = new ConcurrentQueue<float[]>();
-        _pendingS16Samples = new ConcurrentQueue<short[]>();
-        _cts = new CancellationTokenSource();
-
-        // Start audio processing thread
         _audioThread = new Thread(AudioLoop)
         {
             Name = "OpenTKAudioPlayer",
             IsBackground = true
         };
         _audioThread.Start();
-        
-        Debug.WriteLine("[OpenTKAudioPlayer] Audio thread started");
+
+        if (!_startup.Task.Wait(StartupTimeoutMilliseconds))
+        {
+            RequestShutdown();
+            _audioThread.Join(1_000);
+            throw new TimeoutException("Timed out while initializing the OpenAL audio thread.");
+        }
+
+        var startupError = _startup.Task.GetAwaiter().GetResult();
+        if (startupError != null)
+        {
+            RequestShutdown();
+            _audioThread.Join(1_000);
+
+            var message = startupError is DllNotFoundException
+                ? "OpenAL native library was not found. Ensure the OpenAL Soft runtime is deployed with the application."
+                : $"Failed to initialize OpenAL: {startupError.Message}";
+            throw new InvalidOperationException(message, startupError);
+        }
     }
 
+    /// <inheritdoc />
     public void SetVolume(float volume)
     {
-        var oldVolume = _volume;
-        _volume = Math.Clamp(volume, 0f, 1f);
-        AL.Source(_source, ALSourcef.Gain, _volume);
-        _logger.Log("OpenTKAudioPlayer", "SetVolume", new { OldVolume = oldVolume, NewVolume = _volume });
+        if (Volatile.Read(ref _disposeRequested) != 0)
+            return;
+
+        var clamped = Math.Clamp(volume, 0f, 1f);
+        Interlocked.Exchange(ref _volumeBits, BitConverter.SingleToInt32Bits(clamped));
+        EnqueueCommand(new AudioCommand(AudioCommandKind.SetVolume, clamped));
     }
 
-    /// <summary>
-    /// Queue pre-converted S16 stereo samples directly (more efficient when using SwrContext)
-    /// </summary>
-    public unsafe void QueueSamplesS16(short* samples, int sampleCount)
-    {
-        if (_isDisposed || _isPaused) return;
-        
-        // Copy to managed array
-        var pcmData = new short[sampleCount];
-        for (int i = 0; i < sampleCount; i++)
-        {
-            pcmData[i] = samples[i];
-        }
-        
-        _pendingS16Samples.Enqueue(pcmData);
-    }
-
-    public void QueueSamples(float[] samples)
-    {
-        if (_isDisposed || _isPaused) return;
-        
-        // If input has more channels than output, downmix
-        if (_inputChannels > _channels)
-        {
-            samples = DownmixToStereo(samples, _inputChannels);
-        }
-        
-        _pendingSamples.Enqueue(samples);
-    }
-    
-    private float[] DownmixToStereo(float[] input, int inputChannels)
-    {
-        int samplesPerChannel = input.Length / inputChannels;
-        var output = new float[samplesPerChannel * 2]; // Stereo output
-        
-        for (int i = 0; i < samplesPerChannel; i++)
-        {
-            int inputOffset = i * inputChannels;
-            int outputOffset = i * 2;
-            
-            // Simple downmix: average channels for left/right
-            // For 5.1 (6ch): FL, FR, FC, LFE, BL, BR
-            // Left = FL + 0.707*FC + 0.707*BL
-            // Right = FR + 0.707*FC + 0.707*BR
-            
-            if (inputChannels >= 6)
-            {
-                // 5.1 surround downmix
-                float fl = input[inputOffset + 0];     // Front Left
-                float fr = input[inputOffset + 1];     // Front Right
-                float fc = input[inputOffset + 2];     // Front Center
-                float lfe = input[inputOffset + 3];    // LFE (subwoofer)
-                float bl = input[inputOffset + 4];     // Back Left
-                float br = input[inputOffset + 5];     // Back Right
-                
-                output[outputOffset + 0] = Math.Clamp(fl + 0.707f * fc + 0.707f * bl + 0.5f * lfe, -1f, 1f);
-                output[outputOffset + 1] = Math.Clamp(fr + 0.707f * fc + 0.707f * br + 0.5f * lfe, -1f, 1f);
-            }
-            else
-            {
-                // Generic downmix: average odd channels to left, even to right
-                float left = 0, right = 0;
-                for (int c = 0; c < inputChannels; c++)
-                {
-                    if (c % 2 == 0)
-                        left += input[inputOffset + c];
-                    else
-                        right += input[inputOffset + c];
-                }
-                output[outputOffset + 0] = Math.Clamp(left / (inputChannels / 2f), -1f, 1f);
-                output[outputOffset + 1] = Math.Clamp(right / (inputChannels / 2f), -1f, 1f);
-            }
-        }
-        
-        return output;
-    }
-
+    /// <inheritdoc />
     public void Resume()
     {
-        _isPaused = false;
-        _logger.Log("OpenTKAudioPlayer", "Resume", new { WasPlaying = _isPlaying });
-        
-        // Always try to start playback if we have buffers queued
-        // The AudioLoop will handle the actual start, but we can also try here
-        AL.GetSource(_source, ALGetSourcei.BuffersQueued, out int queued);
-        AL.GetSource(_source, ALGetSourcei.SourceState, out int state);
-        
-        if (queued > 0 && state != (int)ALSourceState.Playing)
-        {
-            AL.SourcePlay(_source);
-            var error = AL.GetError();
-            if (error != ALError.NoError)
-            {
-                Debug.WriteLine($"[OpenTKAudioPlayer] Resume: AL.SourcePlay error: {error}");
-            }
-            else
-            {
-                _isPlaying = true;
-                Debug.WriteLine($"[OpenTKAudioPlayer] Resume: Started playback with {queued} queued buffers");
-            }
-        }
+        if (Volatile.Read(ref _disposeRequested) != 0)
+            return;
+
+        Volatile.Write(ref _desiredPaused, 0);
+        EnqueueCommand(new AudioCommand(AudioCommandKind.Resume));
     }
 
+    /// <inheritdoc />
     public void Pause()
     {
-        _isPaused = true;
-        _logger.Log("OpenTKAudioPlayer", "Pause", null);
-        AL.SourcePause(_source);
+        if (Volatile.Read(ref _disposeRequested) != 0)
+            return;
+
+        Volatile.Write(ref _desiredPaused, 1);
+        EnqueueCommand(new AudioCommand(AudioCommandKind.Pause));
     }
 
-    /// <summary>
-    /// Gets the current audio playback time in seconds based on samples played.
-    /// Accounts for samples currently in playback pipeline for accurate sync.
-    /// </summary>
-    public double GetPlaybackTime()
-    {
-        lock (_syncLock)
-        {
-            // Get OpenAL source offset to account for samples currently being played by hardware
-            // SampleOffset returns the number of sample frames (stereo pairs) currently being played
-            AL.GetSource(_source, ALGetSourcei.SampleOffset, out int sampleOffsetFrames);
-            var error = AL.GetError();
-            if (error != ALError.NoError)
-            {
-                // Fallback if SampleOffset is not supported
-                sampleOffsetFrames = 0;
-            }
-            
-            // Convert sample frames to individual samples (for stereo: frames * channels)
-            var sampleOffset = sampleOffsetFrames * _channels;
-            
-            // Calculate current playback position from what OpenAL has actually played:
-            // - _totalSamplesPlayed tracks fully processed buffers.
-            // - sampleOffset tracks the current position inside the active buffer.
-            // Do not include queued-but-unplayed buffers. FFmpeg can decode audio much
-            // faster than real time, especially for audio-only files, and counting the
-            // queued pipeline makes the media clock run ahead and stop playback early.
-            var currentSamples = _totalSamplesPlayed + sampleOffset;
-            
-            // For stereo audio, _totalSamplesPlayed counts both L and R samples (interleaved)
-            // We need to convert to frames (sample pairs) by dividing by channel count
-            // Then divide by sample rate to get time in seconds
-            // For stereo: time = totalSamples / channels / sampleRate
-            return currentSamples / _channels / (double)_sampleRate;
-        }
-    }
-
+    /// <inheritdoc />
     public void Stop()
     {
-        _logger.Log("OpenTKAudioPlayer", "Stop", null);
-        AL.SourceStop(_source);
-        _isPlaying = false;
-        _hasStartedOnce = false;
-        lock (_syncLock)
+        if (Volatile.Read(ref _disposeRequested) != 0)
+            return;
+
+        var generation = Interlocked.Increment(ref _generation);
+        Volatile.Write(ref _inputCompleted, 0);
+        Volatile.Write(ref _isDrained, 1);
+        PublishPlaybackTime(0);
+        ClearPendingPcm();
+        EnqueueCommand(new AudioCommand(AudioCommandKind.Stop, Generation: generation));
+    }
+
+    /// <inheritdoc />
+    public double GetPlaybackTime() =>
+        BitConverter.Int64BitsToDouble(Interlocked.Read(ref _cachedPlaybackTimeBits));
+
+    /// <inheritdoc />
+    public bool IsDrained => Volatile.Read(ref _isDrained) != 0;
+
+    /// <inheritdoc />
+    public unsafe void QueueSamplesS16(short* samples, int sampleCount) =>
+        QueueSamplesS16(samples, sampleCount, CancellationToken.None);
+
+    /// <inheritdoc />
+    public unsafe void QueueSamplesS16(short* samples, int sampleCount, CancellationToken cancellationToken)
+    {
+        if (sampleCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleCount));
+        if (sampleCount == 0)
+            return;
+        if (samples == null)
+            throw new ArgumentNullException(nameof(samples));
+        if (sampleCount % _channels != 0)
+            throw new ArgumentException("The sample count must contain complete interleaved frames.", nameof(sampleCount));
+
+        var generation = Volatile.Read(ref _generation);
+        EnsureCanQueue(cancellationToken);
+
+        var offset = 0;
+        while (offset < sampleCount)
         {
-            _totalSamplesPlayed = 0;
-            _totalSamplesQueued = 0;
-        }
-        
-        // Clear pending samples
-        while (_pendingSamples.TryDequeue(out _)) { }
-        
-        // Unqueue all buffers
-        AL.GetSource(_source, ALGetSourcei.BuffersQueued, out int queued);
-        if (queued > 0)
-        {
-            var buffers = new int[queued];
-            AL.SourceUnqueueBuffers(_source, queued, buffers);
-            foreach (var buffer in buffers)
-            {
-                _availableBuffers.Enqueue(buffer);
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            var count = Math.Min(SamplesPerPacket, sampleCount - offset);
+            count -= count % _channels;
+            if (count == 0)
+                count = sampleCount - offset;
+
+            var copy = new short[count];
+            for (var index = 0; index < count; index++)
+                copy[index] = samples[offset + index];
+
+            if (!TryEnqueuePcm(new PcmPacket(generation, copy), cancellationToken))
+                return;
+
+            offset += count;
         }
     }
 
-    private bool _hasStartedOnce = false;
-    
+    /// <inheritdoc />
+    public void QueueSamples(float[] samples) =>
+        QueueSamples(samples, CancellationToken.None);
+
+    /// <inheritdoc />
+    public void QueueSamples(float[] samples, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (samples.Length == 0)
+            return;
+        if (samples.Length % _inputChannels != 0)
+            throw new ArgumentException("The sample array must contain complete interleaved frames.", nameof(samples));
+
+        var generation = Volatile.Read(ref _generation);
+        EnsureCanQueue(cancellationToken);
+
+        var output = _inputChannels > _channels
+            ? DownmixToStereo(samples, _inputChannels)
+            : samples;
+
+        var offset = 0;
+        while (offset < output.Length)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var count = Math.Min(SamplesPerPacket, output.Length - offset);
+            count -= count % _channels;
+            if (count == 0)
+                count = output.Length - offset;
+
+            var pcm = new short[count];
+            for (var index = 0; index < count; index++)
+            {
+                var value = output[offset + index];
+                if (!float.IsFinite(value))
+                    value = 0;
+                pcm[index] = (short)Math.Round(Math.Clamp(value, -1f, 1f) * short.MaxValue);
+            }
+
+            if (!TryEnqueuePcm(new PcmPacket(generation, pcm), cancellationToken))
+                return;
+
+            offset += count;
+        }
+    }
+
+    /// <inheritdoc />
+    public void CompleteInput()
+    {
+        if (Volatile.Read(ref _disposeRequested) != 0)
+            return;
+
+        var generation = Volatile.Read(ref _generation);
+        Volatile.Write(ref _inputCompleted, 1);
+        EnqueueCommand(new AudioCommand(AudioCommandKind.CompleteInput, Generation: generation));
+    }
+
+    private void EnsureCanQueue(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposeRequested) != 0, this);
+
+        if (Volatile.Read(ref _workerExited) != 0)
+            throw new InvalidOperationException("The OpenAL audio thread is no longer running.");
+        if (Volatile.Read(ref _inputCompleted) != 0)
+            throw new InvalidOperationException("Input has already been completed. Call Stop before starting another input generation.");
+    }
+
+    private bool TryEnqueuePcm(PcmPacket packet, CancellationToken cancellationToken)
+    {
+        lock (_pcmLock)
+        {
+            while (Volatile.Read(ref _disposeRequested) == 0 &&
+                   Volatile.Read(ref _workerExited) == 0 &&
+                   packet.Generation == Volatile.Read(ref _generation) &&
+                   Volatile.Read(ref _inputCompleted) == 0 &&
+                   _pendingSampleCount + packet.Samples.Length > _maximumPendingSamples)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Monitor.Wait(_pcmLock, 50);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Volatile.Read(ref _disposeRequested) != 0 ||
+                Volatile.Read(ref _workerExited) != 0 ||
+                packet.Generation != Volatile.Read(ref _generation) ||
+                Volatile.Read(ref _inputCompleted) != 0)
+            {
+                return false;
+            }
+
+            _pendingPcm.Enqueue(packet);
+            _pendingSampleCount += packet.Samples.Length;
+            Volatile.Write(ref _isDrained, 0);
+        }
+
+        _wake.Set();
+        return true;
+    }
+
+    private bool TryDequeuePcm(out PcmPacket packet)
+    {
+        lock (_pcmLock)
+        {
+            if (!_pendingPcm.TryDequeue(out packet))
+                return false;
+
+            _pendingSampleCount -= packet.Samples.Length;
+            Monitor.PulseAll(_pcmLock);
+            return true;
+        }
+    }
+
+    private void ClearPendingPcm()
+    {
+        lock (_pcmLock)
+        {
+            _pendingPcm.Clear();
+            _pendingSampleCount = 0;
+            Monitor.PulseAll(_pcmLock);
+        }
+    }
+
+    private bool HasPendingPcm()
+    {
+        lock (_pcmLock)
+            return _pendingPcm.Count != 0;
+    }
+
+    private void EnqueueCommand(AudioCommand command)
+    {
+        _commands.Enqueue(command);
+        _wake.Set();
+    }
+
     private void AudioLoop()
     {
-        var token = _cts.Token;
-
+        var startupSignalled = false;
         try
         {
-            ALC.MakeContextCurrent(_context);
+            InitializeOpenAl();
+            _startup.TrySetResult(null);
+            startupSignalled = true;
+
+            while (!_shutdown.IsCancellationRequested)
+            {
+                if (!ProcessCommands())
+                    break;
+
+                RecycleProcessedBuffers();
+                if (!QueuePendingPcm())
+                    continue;
+
+                UpdatePlaybackState();
+                UpdatePlaybackClock();
+                _wake.WaitOne(2);
+            }
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"[OpenTKAudioPlayer] Failed to make context current on audio thread: {ex.Message}");
+            if (!startupSignalled)
+            {
+                _startup.TrySetResult(ex);
+                startupSignalled = true;
+            }
+            else
+            {
+                Debug.WriteLine($"[OpenTKAudioPlayer] Audio thread stopped: {ex.Message}");
+                _logger.Log("OpenTKAudioPlayer", "AudioThreadFailed", new { Exception = ex.Message });
+            }
         }
-        
-        while (!token.IsCancellationRequested)
+        finally
+        {
+            if (!startupSignalled)
+                _startup.TrySetResult(new InvalidOperationException("The OpenAL audio thread exited during initialization."));
+
+            CleanupOpenAl();
+            ClearPendingPcm();
+            PublishPlaybackTime(0);
+            Volatile.Write(ref _isDrained, 1);
+            Volatile.Write(ref _workerExited, 1);
+            lock (_pcmLock)
+                Monitor.PulseAll(_pcmLock);
+            _logger.Dispose();
+        }
+    }
+
+    private void InitializeOpenAl()
+    {
+        _device = ALC.OpenDevice(null);
+        if (_device == ALDevice.Null)
+            throw new InvalidOperationException("OpenAL could not open the default audio device.");
+
+        _context = ALC.CreateContext(_device, (int[]?)null);
+        if (_context == ALContext.Null)
+            throw new InvalidOperationException($"OpenAL could not create a context ({ALC.GetError(_device)}).");
+
+        ALC.MakeContextCurrent(_context);
+        var contextError = ALC.GetError(_device);
+        if (contextError != AlcError.NoError)
+            throw new InvalidOperationException($"OpenAL could not make its context current ({contextError}).");
+
+        _source = AL.GenSource();
+        ThrowOnAlError("create an audio source");
+
+        for (var index = 0; index < BufferCount; index++)
+        {
+            var buffer = AL.GenBuffer();
+            ThrowOnAlError("create an audio buffer");
+            _allBuffers.Add(buffer);
+            _availableBuffers.Enqueue(buffer);
+        }
+
+        var volume = BitConverter.Int32BitsToSingle(Volatile.Read(ref _volumeBits));
+        AL.Source(_source, ALSourcef.Gain, volume);
+        ThrowOnAlError("set source gain");
+        _logger.Log("OpenTKAudioPlayer", "OpenALReady", new { BufferCount });
+    }
+
+    private bool ProcessCommands()
+    {
+        while (_commands.TryDequeue(out var command))
+        {
+            switch (command.Kind)
+            {
+                case AudioCommandKind.SetVolume:
+                    AL.Source(_source, ALSourcef.Gain, command.Value);
+                    LogAlError("set source gain");
+                    break;
+
+                case AudioCommandKind.Resume:
+                    Volatile.Write(ref _desiredPaused, 0);
+                    break;
+
+                case AudioCommandKind.Pause:
+                    Volatile.Write(ref _desiredPaused, 1);
+                    AL.SourcePause(_source);
+                    LogAlError("pause playback");
+                    break;
+
+                case AudioCommandKind.Stop:
+                    if (command.Generation == Volatile.Read(ref _generation))
+                    {
+                        StopOpenAlPipeline();
+                        _workerInputCompleted = false;
+                    }
+                    break;
+
+                case AudioCommandKind.CompleteInput:
+                    if (command.Generation == Volatile.Read(ref _generation))
+                        _workerInputCompleted = true;
+                    break;
+
+                case AudioCommandKind.Shutdown:
+                    return false;
+            }
+        }
+
+        return !_shutdown.IsCancellationRequested;
+    }
+
+    private void RecycleProcessedBuffers()
+    {
+        AL.GetSource(_source, ALGetSourcei.BuffersProcessed, out var processed);
+        if (!LogAlError("query processed buffers"))
+            return;
+
+        while (processed-- > 0)
+        {
+            var buffer = AL.SourceUnqueueBuffer(_source);
+            if (!LogAlError("unqueue a processed buffer"))
+                break;
+
+            if (_bufferSampleCounts.Remove(buffer, out var sampleCount))
+                _playedSamples += sampleCount;
+            _availableBuffers.Enqueue(buffer);
+        }
+    }
+
+    private bool QueuePendingPcm()
+    {
+        while (_availableBuffers.Count > 0 && TryDequeuePcm(out var packet))
+        {
+            var currentGeneration = Volatile.Read(ref _generation);
+            if (packet.Generation != currentGeneration)
+                continue;
+
+            var buffer = _availableBuffers.Dequeue();
+            var format = _channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16;
+            AL.BufferData(buffer, format, packet.Samples, _sampleRate);
+            if (!LogAlError("fill an audio buffer"))
+            {
+                _availableBuffers.Enqueue(buffer);
+                continue;
+            }
+
+            if (packet.Generation != Volatile.Read(ref _generation))
+            {
+                _availableBuffers.Enqueue(buffer);
+                StopOpenAlPipeline();
+                return false;
+            }
+
+            AL.SourceQueueBuffer(_source, buffer);
+            if (!LogAlError("queue an audio buffer"))
+            {
+                _availableBuffers.Enqueue(buffer);
+                continue;
+            }
+
+            _bufferSampleCounts[buffer] = packet.Samples.Length;
+            if (_firstQueuedTimestamp == 0)
+                _firstQueuedTimestamp = Stopwatch.GetTimestamp();
+
+            if (packet.Generation != Volatile.Read(ref _generation))
+            {
+                StopOpenAlPipeline();
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void UpdatePlaybackState()
+    {
+        AL.GetSource(_source, ALGetSourcei.SourceState, out var stateValue);
+        if (!LogAlError("query source state"))
+            return;
+
+        AL.GetSource(_source, ALGetSourcei.BuffersQueued, out var queued);
+        if (!LogAlError("query queued buffers"))
+            return;
+
+        var state = (ALSourceState)stateValue;
+        var paused = Volatile.Read(ref _desiredPaused) != 0;
+        if (!paused && state != ALSourceState.Playing && queued > 0)
+        {
+            var waitedLongEnough = _firstQueuedTimestamp != 0 &&
+                Stopwatch.GetElapsedTime(_firstQueuedTimestamp).TotalMilliseconds >= InitialStartDelayMilliseconds;
+            var shouldStart = _hasStartedOnce ||
+                queued >= InitialBufferTarget ||
+                _workerInputCompleted ||
+                waitedLongEnough;
+
+            if (shouldStart)
+            {
+                AL.SourcePlay(_source);
+                if (LogAlError("start playback"))
+                    _hasStartedOnce = true;
+            }
+        }
+
+        var drained = _workerInputCompleted && queued == 0 && !HasPendingPcm();
+        Volatile.Write(ref _isDrained, drained ? 1 : 0);
+    }
+
+    private void UpdatePlaybackClock()
+    {
+        var offsetFrames = 0;
+        AL.GetSource(_source, ALGetSourcei.SampleOffset, out offsetFrames);
+        if (!LogAlError("query playback offset"))
+            offsetFrames = 0;
+
+        var currentSamples = _playedSamples + (long)offsetFrames * _channels;
+        PublishPlaybackTime(currentSamples / _channels / (double)_sampleRate);
+    }
+
+    private void StopOpenAlPipeline()
+    {
+        AL.SourceStop(_source);
+        LogAlError("stop playback");
+
+        AL.GetSource(_source, ALGetSourcei.BuffersQueued, out var queued);
+        if (LogAlError("query buffers while stopping") && queued > 0)
+        {
+            var buffers = new int[queued];
+            AL.SourceUnqueueBuffers(_source, queued, buffers);
+            LogAlError("unqueue buffers while stopping");
+        }
+
+        _availableBuffers.Clear();
+        foreach (var buffer in _allBuffers)
+            _availableBuffers.Enqueue(buffer);
+        _bufferSampleCounts.Clear();
+        _playedSamples = 0;
+        _hasStartedOnce = false;
+        _firstQueuedTimestamp = 0;
+        PublishPlaybackTime(0);
+    }
+
+    private void CleanupOpenAl()
+    {
+        try
+        {
+            if (_context != ALContext.Null)
+                ALC.MakeContextCurrent(_context);
+
+            if (_source != 0)
+            {
+                try
+                {
+                    StopOpenAlPipeline();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[OpenTKAudioPlayer] Failed to stop during cleanup: {ex.Message}");
+                }
+
+                AL.DeleteSource(_source);
+                LogAlError("delete the audio source");
+                _source = 0;
+            }
+
+            foreach (var buffer in _allBuffers)
+            {
+                AL.DeleteBuffer(buffer);
+                LogAlError("delete an audio buffer");
+            }
+            _allBuffers.Clear();
+            _availableBuffers.Clear();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[OpenTKAudioPlayer] OpenAL cleanup failed: {ex.Message}");
+        }
+        finally
         {
             try
             {
-                // Check for processed buffers to recycle
-                AL.GetSource(_source, ALGetSourcei.BuffersProcessed, out int processed);
-                while (processed > 0)
+                if (_context != ALContext.Null)
                 {
-                    var buffer = AL.SourceUnqueueBuffer(_source);
-                    _availableBuffers.Enqueue(buffer);
-                    
-                    // Track samples played for synchronization
-                    AL.GetBuffer(buffer, ALGetBufferi.Size, out int bufferSize);
-                    // bufferSize is in bytes, each sample is 2 bytes, so total samples = bufferSize / 2
-                    // For stereo, this gives total samples (left + right)
-                    int samplesInBuffer = bufferSize / 2;
-                    lock (_syncLock)
-                    {
-                        _totalSamplesPlayed += samplesInBuffer;
-                    }
-                    
-                    processed--;
+                    ALC.MakeContextCurrent(ALContext.Null);
+                    ALC.DestroyContext(_context);
+                    _context = ALContext.Null;
                 }
 
-                // Queue S16 samples first (from SwrContext - already in correct format)
-                int s16Queued = 0;
-                while (_availableBuffers.TryDequeue(out var buffer))
+                if (_device != ALDevice.Null)
                 {
-                    if (!_pendingS16Samples.TryDequeue(out var pcmData))
-                    {
-                        _availableBuffers.Enqueue(buffer);
-                        break;
-                    }
-
-                    AL.BufferData(buffer, ALFormat.Stereo16, pcmData, _sampleRate);
-                    var bufferError = AL.GetError();
-                    if (bufferError != ALError.NoError)
-                    {
-                        Debug.WriteLine($"[OpenTKAudioPlayer] AL.BufferData error: {bufferError}");
-                        _availableBuffers.Enqueue(buffer); // Return buffer on error
-                        break;
-                    }
-                    
-                    AL.SourceQueueBuffer(_source, buffer);
-                    var queueError = AL.GetError();
-                    if (queueError != ALError.NoError)
-                    {
-                        Debug.WriteLine($"[OpenTKAudioPlayer] AL.SourceQueueBuffer error: {queueError}");
-                        _availableBuffers.Enqueue(buffer); // Return buffer on error
-                        break;
-                    }
-                    
-                    s16Queued++;
-                    
-                    // Track samples queued (pcmData.Length is total samples for stereo interleaved)
-                    lock (_syncLock)
-                    {
-                        _totalSamplesQueued += pcmData.Length;
-                    }
+                    ALC.CloseDevice(_device);
+                    _device = ALDevice.Null;
                 }
-
-                // Queue float samples (fallback - convert to S16)
-                int floatQueued = 0;
-                while (_availableBuffers.TryDequeue(out var buffer))
-                {
-                    if (!_pendingSamples.TryDequeue(out var samples))
-                    {
-                        _availableBuffers.Enqueue(buffer);
-                        break;
-                    }
-
-                    // Convert float samples to 16-bit PCM
-                    var pcmData = new short[samples.Length];
-                    for (int i = 0; i < samples.Length; i++)
-                    {
-                        pcmData[i] = (short)(samples[i] * 32767);
-                    }
-
-                    var format = _channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16;
-                    AL.BufferData(buffer, format, pcmData, _sampleRate);
-                    var bufferError = AL.GetError();
-                    if (bufferError != ALError.NoError)
-                    {
-                        Debug.WriteLine($"[OpenTKAudioPlayer] AL.BufferData (float) error: {bufferError}");
-                        _availableBuffers.Enqueue(buffer); // Return buffer on error
-                        break;
-                    }
-                    
-                    AL.SourceQueueBuffer(_source, buffer);
-                    var queueError = AL.GetError();
-                    if (queueError != ALError.NoError)
-                    {
-                        Debug.WriteLine($"[OpenTKAudioPlayer] AL.SourceQueueBuffer (float) error: {queueError}");
-                        _availableBuffers.Enqueue(buffer); // Return buffer on error
-                        break;
-                    }
-                    
-                    floatQueued++;
-                    
-                    // Track samples queued (samples.Length is total sample count for stereo interleaved)
-                    lock (_syncLock)
-                    {
-                        _totalSamplesQueued += samples.Length;
-                    }
-                }
-                
-                if (s16Queued > 0 || floatQueued > 0)
-                {
-                    AL.GetSource(_source, ALGetSourcei.BuffersQueued, out int totalQueued);
-                    _logger.Log("OpenTKAudioPlayer", "BuffersQueued", new 
-                    { 
-                        S16Buffers = s16Queued,
-                        FloatBuffers = floatQueued,
-                        TotalQueued = totalQueued,
-                        AvailableBuffers = _availableBuffers.Count,
-                        PendingS16 = _pendingS16Samples.Count,
-                        PendingFloat = _pendingSamples.Count
-                    });
-                }
-
-                // Start or resume playback
-                AL.GetSource(_source, ALGetSourcei.SourceState, out int state);
-                AL.GetSource(_source, ALGetSourcei.BuffersQueued, out int queued);
-                
-                if (!_isPaused && state != (int)ALSourceState.Playing && queued > 0)
-                {
-                    // First time start: wait for enough buffers
-                    // Subsequent restarts: start immediately if we have any buffers
-                    if (!_hasStartedOnce && queued >= 4)
-                    {
-                        Debug.WriteLine($"[OpenTKAudioPlayer] Initial playback start with {queued} queued buffers");
-                        _logger.Log("OpenTKAudioPlayer", "PlaybackStarted", new { QueuedBuffers = queued, Reason = "Initial start" });
-                        AL.SourcePlay(_source);
-                        var error = AL.GetError();
-                        if (error != ALError.NoError)
-                        {
-                            Debug.WriteLine($"[OpenTKAudioPlayer] AL.SourcePlay (initial) error: {error}");
-                        }
-                        else
-                        {
-                            _isPlaying = true;
-                            _hasStartedOnce = true;
-                            Debug.WriteLine($"[OpenTKAudioPlayer] Playback started successfully");
-                        }
-                    }
-                    else if (_hasStartedOnce && queued >= 1)
-                    {
-                        // Restart after buffer underrun
-                        _logger.Log("OpenTKAudioPlayer", "PlaybackRestarted", new { QueuedBuffers = queued, Reason = "Buffer underrun recovery" });
-                        AL.SourcePlay(_source);
-                        var error = AL.GetError();
-                        if (error != ALError.NoError)
-                        {
-                            Debug.WriteLine($"[OpenTKAudioPlayer] AL.SourcePlay (restart) error: {error}");
-                        }
-                        else
-                        {
-                            _isPlaying = true;
-                        }
-                    }
-                }
-
-                Thread.Sleep(2); // Fast polling for smooth audio with reduced CPU usage
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[OpenTKAudioPlayer] Error: {ex.Message}");
-                Thread.Sleep(10);
+                Debug.WriteLine($"[OpenTKAudioPlayer] OpenAL context cleanup failed: {ex.Message}");
             }
         }
+    }
+
+    private static float[] DownmixToStereo(float[] input, int inputChannels)
+    {
+        var frameCount = input.Length / inputChannels;
+        var output = new float[frameCount * 2];
+
+        for (var frame = 0; frame < frameCount; frame++)
+        {
+            var inputOffset = frame * inputChannels;
+            var outputOffset = frame * 2;
+
+            if (inputChannels >= 6)
+            {
+                var frontLeft = input[inputOffset];
+                var frontRight = input[inputOffset + 1];
+                var center = input[inputOffset + 2];
+                var lfe = input[inputOffset + 3];
+                var backLeft = input[inputOffset + 4];
+                var backRight = input[inputOffset + 5];
+
+                output[outputOffset] = Math.Clamp(frontLeft + 0.707f * center + 0.707f * backLeft + 0.5f * lfe, -1f, 1f);
+                output[outputOffset + 1] = Math.Clamp(frontRight + 0.707f * center + 0.707f * backRight + 0.5f * lfe, -1f, 1f);
+            }
+            else
+            {
+                float left = 0;
+                float right = 0;
+                var leftCount = 0;
+                var rightCount = 0;
+                for (var channel = 0; channel < inputChannels; channel++)
+                {
+                    if ((channel & 1) == 0)
+                    {
+                        left += input[inputOffset + channel];
+                        leftCount++;
+                    }
+                    else
+                    {
+                        right += input[inputOffset + channel];
+                        rightCount++;
+                    }
+                }
+
+                output[outputOffset] = Math.Clamp(left / Math.Max(leftCount, 1), -1f, 1f);
+                output[outputOffset + 1] = Math.Clamp(right / Math.Max(rightCount, 1), -1f, 1f);
+            }
+        }
+
+        return output;
+    }
+
+    private void PublishPlaybackTime(double seconds) =>
+        Interlocked.Exchange(ref _cachedPlaybackTimeBits, BitConverter.DoubleToInt64Bits(seconds));
+
+    private void ThrowOnAlError(string operation)
+    {
+        var error = AL.GetError();
+        if (error != ALError.NoError)
+            throw new InvalidOperationException($"OpenAL failed to {operation} ({error}).");
+    }
+
+    private bool LogAlError(string operation)
+    {
+        var error = AL.GetError();
+        if (error == ALError.NoError)
+            return true;
+
+        Debug.WriteLine($"[OpenTKAudioPlayer] OpenAL failed to {operation}: {error}");
+        _logger.Log("OpenTKAudioPlayer", "OpenALError", new { Operation = operation, Error = error.ToString() });
+        return false;
+    }
+
+    private void RequestShutdown()
+    {
+        if (Interlocked.Exchange(ref _disposeRequested, 1) != 0)
+            return;
+
+        Interlocked.Increment(ref _generation);
+        Volatile.Write(ref _inputCompleted, 1);
+        ClearPendingPcm();
+        _commands.Enqueue(new AudioCommand(AudioCommandKind.Shutdown));
+        _shutdown.Cancel();
+        _wake.Set();
     }
 
     public void Dispose()
     {
-        if (_isDisposed) return;
-        _isDisposed = true;
+        if (Volatile.Read(ref _disposeRequested) != 0)
+            return;
 
         _logger.Log("OpenTKAudioPlayer", "Dispose", null);
-        _cts.Cancel();
-        _audioThread.Join(1000);
-        _cts.Dispose();
+        RequestShutdown();
 
-        Stop();
+        if (Thread.CurrentThread == _audioThread)
+            return;
 
-        // Delete buffers
-        while (_availableBuffers.TryDequeue(out var buffer))
+        if (!_audioThread.Join(DisposeJoinTimeoutMilliseconds))
         {
-            AL.DeleteBuffer(buffer);
+            // Native resources remain owned by the still-running audio thread. It will
+            // destroy them in its finally block if/when the blocking driver call returns.
+            Debug.WriteLine("[OpenTKAudioPlayer] Audio thread did not stop before the dispose timeout; native cleanup was deferred to that thread.");
+            _logger.Log("OpenTKAudioPlayer", "DisposeDeferred", new { DisposeJoinTimeoutMilliseconds });
         }
+    }
 
-        AL.DeleteSource(_source);
+    private readonly record struct PcmPacket(int Generation, short[] Samples);
 
-        if (_context != ALContext.Null)
-        {
-            ALC.MakeContextCurrent(ALContext.Null);
-            ALC.DestroyContext(_context);
-        }
+    private readonly record struct AudioCommand(
+        AudioCommandKind Kind,
+        float Value = 0,
+        int Generation = 0);
 
-        if (_device != ALDevice.Null)
-        {
-            ALC.CloseDevice(_device);
-        }
-        
-        _logger.Dispose();
+    private enum AudioCommandKind
+    {
+        SetVolume,
+        Resume,
+        Pause,
+        Stop,
+        CompleteInput,
+        Shutdown
     }
 }
-

--- a/FFmpegVideoPlayer.Avalonia.sln
+++ b/FFmpegVideoPlayer.Avalonia.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FFmpegVideoPlayer.Audio.Ope
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.FFmpegVideoPlayer", "Avalonia.FFmpegVideoPlayer.csproj", "{5F4E23BE-2A01-49C0-AF81-B1CB06F914EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FFmpegVideoPlayer.Tests", "tests\FFmpegVideoPlayer.Tests\FFmpegVideoPlayer.Tests.csproj", "{C38B132A-E585-4B58-9CC2-2B95103CB14D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{5F4E23BE-2A01-49C0-AF81-B1CB06F914EB}.Release|x64.Build.0 = Release|Any CPU
 		{5F4E23BE-2A01-49C0-AF81-B1CB06F914EB}.Release|x86.ActiveCfg = Release|Any CPU
 		{5F4E23BE-2A01-49C0-AF81-B1CB06F914EB}.Release|x86.Build.0 = Release|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Debug|x64.Build.0 = Debug|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Debug|x86.Build.0 = Debug|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Release|x64.ActiveCfg = Release|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Release|x64.Build.0 = Release|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Release|x86.ActiveCfg = Release|Any CPU
+		{C38B132A-E585-4B58-9CC2-2B95103CB14D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FFmpegVideoPlayer.Core/FFmpegMediaPlayer.Async.cs
+++ b/FFmpegVideoPlayer.Core/FFmpegMediaPlayer.Async.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FFmpegVideoPlayer.Core;
+
+public sealed partial class FFmpegMediaPlayer
+{
+    /// <summary>
+    /// Resolves and opens a typed media source without blocking the caller's thread.
+    /// A newer open cancels the previous one and the player owns the resolved session.
+    /// </summary>
+    public async Task<MediaOpenResult> OpenAsync(
+        MediaSource source,
+        MediaOpenOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        options ??= MediaOpenOptions.Default;
+        options.Validate();
+
+        CancellationTokenSource operationCancellation;
+        lock (_openOperationLock)
+        {
+            _activeOpenCancellation?.Cancel();
+            operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _activeOpenCancellation = operationCancellation;
+        }
+
+        MediaSourceSession? session = null;
+        var gateEntered = false;
+        var resetPerformed = false;
+        try
+        {
+            await _openGate.WaitAsync(operationCancellation.Token).ConfigureAwait(false);
+            gateEntered = true;
+            Interlocked.Exchange(ref _openGateHeld, 1);
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+            operationCancellation.Token.ThrowIfCancellationRequested();
+            var previousSession = ResetForOpen();
+            resetPerformed = true;
+            if (previousSession is not null)
+                await previousSession.DisposeAsync().ConfigureAwait(false);
+            SetState(PlaybackState.Opening);
+            session = await source.OpenSessionAsync(operationCancellation.Token).ConfigureAwait(false);
+            operationCancellation.Token.ThrowIfCancellationRequested();
+
+            var opened = await Task.Run(
+                    () => OpenResolved(
+                        session.Location,
+                        source,
+                        session,
+                        options,
+                        operationCancellation.Token),
+                    operationCancellation.Token)
+                .ConfigureAwait(false);
+            operationCancellation.Token.ThrowIfCancellationRequested();
+
+            if (!opened)
+            {
+                if (operationCancellation.IsCancellationRequested ||
+                    _lastError?.Code == MediaErrorCode.Cancelled)
+                {
+                    throw new OperationCanceledException(operationCancellation.Token);
+                }
+
+                await session.DisposeAsync().ConfigureAwait(false);
+                session = null;
+                var error = _lastError ?? new MediaError(
+                    MediaErrorCode.Unknown,
+                    $"Could not open '{source.DisplayName}'.");
+                SetState(PlaybackState.Failed);
+                RaiseMediaFailed(error, source);
+                return MediaOpenResult.Failure(error);
+            }
+
+            session = null; // Ownership transferred by OpenResolved.
+            var mediaInfo = _mediaInfo ?? new MediaInfo(
+                source.DisplayName,
+                TimeSpan.FromMilliseconds(Length),
+                HasVideo,
+                HasAudio,
+                VideoWidth,
+                VideoHeight);
+            return MediaOpenResult.Success(mediaInfo);
+        }
+        catch (OperationCanceledException)
+        {
+            if (resetPerformed)
+                RollbackFailedOpen(session);
+            if (session is not null)
+                await session.DisposeAsync().ConfigureAwait(false);
+            if (resetPerformed)
+                SetState(PlaybackState.Closed);
+            throw;
+        }
+        catch (ObjectDisposedException) when (_isDisposed)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (resetPerformed)
+                RollbackFailedOpen(session);
+            if (session is not null)
+                await session.DisposeAsync().ConfigureAwait(false);
+            var errorCode = ex switch
+            {
+                FileNotFoundException => MediaErrorCode.SourceNotFound,
+                HttpRequestException => MediaErrorCode.Network,
+                DllNotFoundException or EntryPointNotFoundException or BadImageFormatException =>
+                    MediaErrorCode.NativeLibraryUnavailable,
+                _ => MediaErrorCode.InvalidSource
+            };
+            var error = new MediaError(
+                errorCode,
+                $"Could not prepare '{source.DisplayName}'.",
+                Exception: ex);
+            _lastError = error;
+            SetState(PlaybackState.Failed);
+            RaiseMediaFailed(error, source);
+            return MediaOpenResult.Failure(error);
+        }
+        finally
+        {
+            if (gateEntered)
+            {
+                Interlocked.Exchange(ref _openGateHeld, 0);
+                _openGate.Release();
+            }
+            lock (_openOperationLock)
+            {
+                if (ReferenceEquals(_activeOpenCancellation, operationCancellation))
+                    _activeOpenCancellation = null;
+            }
+            operationCancellation.Dispose();
+        }
+    }
+}

--- a/FFmpegVideoPlayer.Core/FFmpegMediaPlayer.cs
+++ b/FFmpegVideoPlayer.Core/FFmpegMediaPlayer.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using FFmpeg.AutoGen;
 
 namespace FFmpegVideoPlayer.Core;
@@ -14,8 +17,9 @@ namespace FFmpegVideoPlayer.Core;
 /// Provides cross-platform support including ARM64 macOS.
 /// Uses FFmpeg.AutoGen 8.x bindings (requires FFmpeg 8.x / libavcodec.62).
 /// </summary>
-public sealed unsafe class FFmpegMediaPlayer : IDisposable
+public sealed unsafe partial class FFmpegMediaPlayer : IDisposable, IAsyncDisposable
 {
+    private static readonly AVIOInterruptCB_callback InterruptCallbackDelegate = InterruptCallback;
     private AVFormatContext* _formatContext;
     private AVCodecContext* _videoCodecContext;
     private AVCodecContext* _audioCodecContext;
@@ -32,10 +36,31 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     
     private Thread? _playbackThread;
     private CancellationTokenSource? _cancellationTokenSource;
+    private readonly SemaphoreSlim _openGate = new(1, 1);
+    private int _openGateHeld;
+    private readonly object _openOperationLock = new();
+    private readonly ConcurrentQueue<Action> _eventQueue = new();
+    private int _eventPumpScheduled;
+    private CancellationTokenSource? _activeOpenCancellation;
+    private MediaSourceSession? _mediaSession;
+    private GCHandle _interruptHandle;
+    private CancellationToken _ioCancellationToken;
+    private long _ioDeadlineTimestamp;
+    private int _interruptRequested;
+    private int _ioTimedOut;
+    private TimeSpan _readTimeout = MediaOpenOptions.Default.ReadTimeout;
     
     private bool _isPlaying;
     private bool _isPaused;
     private bool _isDisposed;
+    private bool _isClosing;
+    private int _disposeState;
+    private readonly TaskCompletionSource _disposeCompletion = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private PlaybackState _state = PlaybackState.Closed;
+    private MediaInfo? _mediaInfo;
+    private MediaSource? _mediaSource;
+    private MediaError? _lastError;
     private double _position;
     private double _duration;
     private int _volume = 100;
@@ -144,12 +169,22 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     {
         _synchronizationCallback = synchronizationCallback;
         _audioPlayerFactory = audioPlayerFactory;
+        _interruptHandle = GCHandle.Alloc(this, GCHandleType.Normal);
     }
 
     /// <summary>
     /// Gets whether media is currently playing.
     /// </summary>
     public bool IsPlaying => _isPlaying && !_isPaused;
+
+    /// <summary>Gets the current lifecycle state.</summary>
+    public PlaybackState State => _state;
+
+    /// <summary>Gets information about the currently opened media.</summary>
+    public MediaInfo? MediaInfo => _mediaInfo;
+
+    /// <summary>Gets the most recent media failure.</summary>
+    public MediaError? LastError => _lastError;
 
     /// <summary>
     /// Gets the current position as a percentage (0.0 to 1.0).
@@ -231,43 +266,109 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     /// </summary>
     public event EventHandler? EndReached;
 
-    /// <summary>
-    /// Opens a media file for playback.
-    /// </summary>
-    /// <param name="path">The path to the media file.</param>
-    /// <returns>True if the file was opened successfully.</returns>
-    public bool Open(string path)
+    /// <summary>Raised when an open or playback operation fails.</summary>
+    public event EventHandler<MediaFailedEventArgs>? MediaFailed;
+
+    /// <summary>Raised whenever <see cref="State"/> changes.</summary>
+    public event EventHandler<PlaybackStateChangedEventArgs>? StateChanged;
+
+    /// <summary>Opens a local path, direct URI, or supported provider URL.</summary>
+    public bool Open(string path) => Open(MediaSource.FromLocation(path)).Succeeded;
+
+    /// <summary>Synchronously opens a typed media source.</summary>
+    public MediaOpenResult Open(
+        MediaSource source,
+        MediaOpenOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        OpenAsync(source, options, cancellationToken).GetAwaiter().GetResult();
+
+    /// <summary>Cancels source resolution and blocking FFmpeg I/O.</summary>
+    public void CancelPendingOpen()
+    {
+        var hasActiveOpen = false;
+        lock (_openOperationLock)
+        {
+            if (_activeOpenCancellation is not null)
+            {
+                hasActiveOpen = true;
+                _activeOpenCancellation.Cancel();
+            }
+        }
+
+        if (hasActiveOpen)
+            Interlocked.Exchange(ref _interruptRequested, 1);
+    }
+
+    private void RollbackFailedOpen(MediaSourceSession? session)
     {
         lock (_lock)
         {
+            if (ReferenceEquals(_mediaSession, session))
+                _mediaSession = null;
+            CloseInternal();
+            _mediaInfo = null;
+            _mediaSource = null;
+        }
+    }
+
+    private MediaSourceSession? ResetForOpen()
+        => CloseWhileOpenGateHeld();
+
+    private bool OpenResolved(
+        string path,
+        MediaSource source,
+        MediaSourceSession session,
+        MediaOpenOptions options,
+        CancellationToken cancellationToken)
+    {
+        var displayName = source.DisplayName;
+        long? openedLength = null;
+        lock (_lock)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Interlocked.Exchange(ref _interruptRequested, 0);
+            Interlocked.Exchange(ref _ioTimedOut, 0);
+            _lastError = null;
+            _mediaInfo = null;
+            _readTimeout = options.ReadTimeout;
+
             // Clear logs when opening a new movie
             _logger.Clear();
-            _logger.Log("FFmpegMediaPlayer", "MovieLoadingStarted", new { Path = path, Timestamp = DateTime.Now });
+            _logger.Log("FFmpegMediaPlayer", "MediaLoadingStarted", new { DisplayName = displayName });
             
-            CloseInternal();
-
             _pendingFrameCount = 0;
             _droppedFrames = 0;
 
-            _logger.Log("FFmpegMediaPlayer", "OpeningMediaFile", new { Path = path });
-            
-            fixed (AVFormatContext** formatContext = &_formatContext)
+            _logger.Log("FFmpegMediaPlayer", "OpeningMedia", new { DisplayName = displayName });
+
+            var openResult = OpenFormatContext(path, session, options.OpenTimeout, cancellationToken);
+            if (openResult < 0)
             {
-                if (ffmpeg.avformat_open_input(formatContext, path, null, null) != 0)
-                {
-                    Debug.WriteLine($"[FFmpegMediaPlayer] Failed to open media: {path}");
-                    _logger.Log("FFmpegMediaPlayer", "OpenFailed", new { Path = path, Reason = "avformat_open_input failed" });
-                    return false;
-                }
+                _lastError = CreateMediaError(openResult, displayName, cancellationToken);
+                _logger.Log("FFmpegMediaPlayer", "OpenFailed", new { DisplayName = displayName, NativeError = openResult });
+                CloseInternal();
+                return false;
             }
             
-            _logger.Log("FFmpegMediaPlayer", "MediaFileOpened", new { Path = path });
+            _logger.Log("FFmpegMediaPlayer", "MediaFileOpened", new { DisplayName = displayName });
 
             _logger.Log("FFmpegMediaPlayer", "ReadingStreamInfo", null);
-            if (ffmpeg.avformat_find_stream_info(_formatContext, null) < 0)
+            BeginIo(cancellationToken, options.OpenTimeout);
+            int streamInfoResult;
+            try
+            {
+                streamInfoResult = ffmpeg.avformat_find_stream_info(_formatContext, null);
+            }
+            finally
+            {
+                EndIo();
+            }
+
+            if (streamInfoResult < 0)
             {
                 Debug.WriteLine("[FFmpegMediaPlayer] Failed to read stream info.");
-                _logger.Log("FFmpegMediaPlayer", "StreamInfoFailed", new { Reason = "avformat_find_stream_info failed" });
+                _lastError = CreateMediaError(streamInfoResult, displayName, cancellationToken);
+                _logger.Log("FFmpegMediaPlayer", "StreamInfoFailed", new { NativeError = streamInfoResult });
                 CloseInternal();
                 return false;
             }
@@ -394,6 +495,9 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             if (_videoStreamIndex < 0 && _audioStreamIndex < 0)
             {
                 Debug.WriteLine("[FFmpegMediaPlayer] No playable streams found in media.");
+                _lastError = new MediaError(
+                    MediaErrorCode.UnsupportedFormat,
+                    $"'{displayName}' contains no audio or video streams supported by FFmpeg.");
                 CloseInternal();
                 return false;
             }
@@ -477,6 +581,18 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             if (_videoStreamIndex < 0 && _audioStreamIndex < 0)
             {
                 Debug.WriteLine("[FFmpegMediaPlayer] Media does not contain a supported audio or video stream.");
+                _lastError = new MediaError(
+                    MediaErrorCode.DecoderUnavailable,
+                    $"No decoder is available for the audio or video in '{displayName}'.");
+                CloseInternal();
+                return false;
+            }
+
+            if (_videoStreamIndex < 0 && _audioStreamIndex >= 0 && _audioPlayer is null)
+            {
+                _lastError = new MediaError(
+                    MediaErrorCode.AudioOutputUnavailable,
+                    $"No audio output is available for '{displayName}'.");
                 CloseInternal();
                 return false;
             }
@@ -485,7 +601,7 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             if (_formatContext->duration != ffmpeg.AV_NOPTS_VALUE)
             {
                 _duration = _formatContext->duration / (double)ffmpeg.AV_TIME_BASE;
-                LengthChanged?.Invoke(this, new LengthChangedEventArgs((long)(_duration * 1000)));
+                openedLength = (long)(_duration * 1000);
             }
 
             // Allocate packet
@@ -494,6 +610,9 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             {
                 Debug.WriteLine("[FFmpegMediaPlayer] Failed to allocate packet.");
                 _logger.Log("FFmpegMediaPlayer", "PacketAllocationFailed", null);
+                _lastError = new MediaError(
+                    MediaErrorCode.PlaybackFailed,
+                    $"FFmpeg could not allocate a packet for '{displayName}'.");
                 CloseInternal();
                 return false;
             }
@@ -510,9 +629,9 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             _pauseStartTime = 0;
             _seekTargetPts = -1;
 
-            _logger.Log("FFmpegMediaPlayer", "MovieLoadingCompleted", new
+            _logger.Log("FFmpegMediaPlayer", "MediaLoadingCompleted", new
             { 
-                Path = path,
+                DisplayName = displayName,
                 Duration = _duration,
                 VideoStreamIndex = _videoStreamIndex,
                 AudioStreamIndex = _audioStreamIndex,
@@ -522,7 +641,211 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
                 Timestamp = DateTime.Now
             });
 
-            return true;
+            _mediaSession = session;
+            _mediaSource = source;
+            _mediaInfo = new MediaInfo(
+                displayName,
+                TimeSpan.FromSeconds(_duration),
+                HasVideo,
+                HasAudio,
+                _videoWidth,
+                _videoHeight);
+        }
+
+        if (openedLength is long length)
+            RaiseSynchronized(() => LengthChanged?.Invoke(this, new LengthChangedEventArgs(length)));
+        SetState(PlaybackState.Ready);
+        return true;
+    }
+
+    private int OpenFormatContext(
+        string location,
+        MediaSourceSession session,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        AVDictionary* dictionary = null;
+        try
+        {
+            foreach (var (key, value) in session.FFmpegOptions)
+                ffmpeg.av_dict_set(&dictionary, key, value, 0);
+
+            if (session.Headers.Count > 0)
+            {
+                var headers = string.Concat(session.Headers.Select(pair => $"{pair.Key}: {pair.Value}\r\n"));
+                ffmpeg.av_dict_set(&dictionary, "headers", headers, 0);
+            }
+
+            _formatContext = ffmpeg.avformat_alloc_context();
+            if (_formatContext == null)
+                return ffmpeg.AVERROR(12); // ENOMEM
+
+            _formatContext->interrupt_callback = new AVIOInterruptCB
+            {
+                callback = InterruptCallbackDelegate,
+                opaque = (void*)GCHandle.ToIntPtr(_interruptHandle)
+            };
+
+            BeginIo(cancellationToken, timeout);
+            var context = _formatContext;
+            var result = ffmpeg.avformat_open_input(&context, location, null, &dictionary);
+            _formatContext = context;
+            return result;
+        }
+        finally
+        {
+            EndIo();
+            ffmpeg.av_dict_free(&dictionary);
+        }
+    }
+
+    private void BeginIo(CancellationToken cancellationToken, TimeSpan timeout)
+    {
+        _ioCancellationToken = cancellationToken;
+        var timeoutTicks = timeout.TotalSeconds * Stopwatch.Frequency;
+        Volatile.Write(
+            ref _ioDeadlineTimestamp,
+            Stopwatch.GetTimestamp() + (long)Math.Min(timeoutTicks, long.MaxValue / 4d));
+    }
+
+    private void EndIo()
+    {
+        _ioCancellationToken = default;
+        Volatile.Write(ref _ioDeadlineTimestamp, 0);
+    }
+
+    private static int InterruptCallback(void* opaque)
+    {
+        if (opaque == null)
+            return 0;
+
+        try
+        {
+            var handle = GCHandle.FromIntPtr((IntPtr)opaque);
+            if (handle.Target is not FFmpegMediaPlayer player)
+                return 1;
+            if (Volatile.Read(ref player._interruptRequested) != 0
+                || player._ioCancellationToken.IsCancellationRequested)
+                return 1;
+
+            var deadline = Volatile.Read(ref player._ioDeadlineTimestamp);
+            if (deadline > 0 && Stopwatch.GetTimestamp() >= deadline)
+            {
+                Interlocked.Exchange(ref player._ioTimedOut, 1);
+                return 1;
+            }
+
+            return 0;
+        }
+        catch
+        {
+            return 1;
+        }
+    }
+
+    private MediaError CreateMediaError(
+        int nativeErrorCode,
+        string displayName,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested || Volatile.Read(ref _interruptRequested) != 0)
+            return new MediaError(MediaErrorCode.Cancelled, $"Opening '{displayName}' was cancelled.", nativeErrorCode);
+        if (Volatile.Read(ref _ioTimedOut) != 0)
+            return new MediaError(MediaErrorCode.Timeout, $"Opening '{displayName}' timed out.", nativeErrorCode);
+
+        var nativeMessage = GetFFmpegError(nativeErrorCode);
+        return new MediaError(
+            MediaErrorCode.UnsupportedFormat,
+            $"FFmpeg could not open '{displayName}': {nativeMessage}",
+            nativeErrorCode);
+    }
+
+    private static string GetFFmpegError(int errorCode)
+    {
+        const int bufferSize = 1024;
+        var buffer = stackalloc byte[bufferSize];
+        return ffmpeg.av_strerror(errorCode, buffer, bufferSize) == 0
+            ? Marshal.PtrToStringUTF8((IntPtr)buffer) ?? $"FFmpeg error {errorCode}"
+            : $"FFmpeg error {errorCode}";
+    }
+
+    private void SetState(PlaybackState state)
+    {
+        var previous = _state;
+        if (previous == state)
+            return;
+        _state = state;
+        RaiseSynchronized(() => StateChanged?.Invoke(
+            this,
+            new PlaybackStateChangedEventArgs(previous, state)));
+    }
+
+    private void RaiseMediaFailed(MediaError error, MediaSource? source = null)
+    {
+        var failedSource = source ?? _mediaSource;
+        RaiseSynchronized(() => MediaFailed?.Invoke(
+            this,
+            new MediaFailedEventArgs(error, failedSource)));
+    }
+
+    private void RaiseSynchronized(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        _eventQueue.Enqueue(action);
+        if (Interlocked.CompareExchange(ref _eventPumpScheduled, 1, 0) == 0)
+            ThreadPool.QueueUserWorkItem(_ => PumpEvents());
+    }
+
+    private void PumpEvents()
+    {
+        while (true)
+        {
+            while (_eventQueue.TryDequeue(out var action))
+                DispatchEventSafely(action);
+
+            Interlocked.Exchange(ref _eventPumpScheduled, 0);
+            if (_eventQueue.IsEmpty ||
+                Interlocked.CompareExchange(ref _eventPumpScheduled, 1, 0) != 0)
+            {
+                return;
+            }
+        }
+    }
+
+    private void DispatchEventSafely(Action action)
+    {
+        void Invoke()
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[FFmpegMediaPlayer] Event subscriber failed: {ex.Message}");
+                _logger.Log("FFmpegMediaPlayer", "EventSubscriberFailed", new
+                {
+                    Exception = ex.GetType().Name,
+                    ex.Message
+                });
+            }
+        }
+
+        try
+        {
+            if (_synchronizationCallback is not null)
+                _synchronizationCallback(Invoke);
+            else
+                Invoke();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[FFmpegMediaPlayer] Event dispatch failed: {ex.Message}");
+            _logger.Log("FFmpegMediaPlayer", "EventDispatchFailed", new
+            {
+                Exception = ex.GetType().Name,
+                ex.Message
+            });
         }
     }
 
@@ -538,13 +861,15 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
         }
 
         _videoCodecContext = ffmpeg.avcodec_alloc_context3(codec);
+        if (_videoCodecContext == null)
+            return false;
         if (ffmpeg.avcodec_parameters_to_context(_videoCodecContext, codecParams) < 0)
         {
             return false;
         }
 
         // Enable multi-threaded decoding
-        _videoCodecContext->thread_count = Math.Max(1, Environment.ProcessorCount - 1);
+        _videoCodecContext->thread_count = Math.Clamp(Environment.ProcessorCount - 1, 1, 16);
         _videoCodecContext->thread_type = ffmpeg.FF_THREAD_FRAME | ffmpeg.FF_THREAD_SLICE;
 
         if (ffmpeg.avcodec_open2(_videoCodecContext, codec, null) < 0)
@@ -554,6 +879,8 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
 
         _videoWidth = _videoCodecContext->width;
         _videoHeight = _videoCodecContext->height;
+        if (_videoWidth <= 0 || _videoHeight <= 0)
+            return false;
 
         // Calculate frame rate
         var timeBase = stream->avg_frame_rate;
@@ -564,16 +891,30 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
         // Allocate frames
         _frame = ffmpeg.av_frame_alloc();
         _rgbFrame = ffmpeg.av_frame_alloc();
+        if (_frame == null || _rgbFrame == null)
+            return false;
 
         // Set up RGB frame
         _rgbBufferSize = ffmpeg.av_image_get_buffer_size(AVPixelFormat.AV_PIX_FMT_BGRA, _videoWidth, _videoHeight, 1);
+        if (_rgbBufferSize <= 0)
+            return false;
         _rgbBuffer = (byte*)ffmpeg.av_malloc((ulong)_rgbBufferSize);
+        if (_rgbBuffer == null)
+            return false;
 
         // Fill the RGB frame data pointers using ref parameters
         byte_ptrArray4 dataPtr = new byte_ptrArray4();
         int_array4 linesizePtr = new int_array4();
         
-        ffmpeg.av_image_fill_arrays(ref dataPtr, ref linesizePtr, _rgbBuffer, AVPixelFormat.AV_PIX_FMT_BGRA, _videoWidth, _videoHeight, 1);
+        if (ffmpeg.av_image_fill_arrays(
+                ref dataPtr,
+                ref linesizePtr,
+                _rgbBuffer,
+                AVPixelFormat.AV_PIX_FMT_BGRA,
+                _videoWidth,
+                _videoHeight,
+                1) < 0)
+            return false;
         
         _rgbFrame->data[0] = dataPtr[0];
         _rgbFrame->data[1] = dataPtr[1];
@@ -606,6 +947,8 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
         }
 
         _audioCodecContext = ffmpeg.avcodec_alloc_context3(codec);
+        if (_audioCodecContext == null)
+            return false;
         if (ffmpeg.avcodec_parameters_to_context(_audioCodecContext, codecParams) < 0)
         {
             Debug.WriteLine("[FFmpegMediaPlayer] Failed to copy audio codec params");
@@ -623,30 +966,35 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
         {
             var sampleRate = _audioCodecContext->sample_rate;
             var channels = _audioCodecContext->ch_layout.nb_channels;
+            if (sampleRate <= 0 || channels <= 0)
+                return false;
             Debug.WriteLine($"[FFmpegMediaPlayer] Audio: sampleRate={sampleRate}, channels={channels}");
             
             // Initialize SwrContext for audio resampling to stereo S16
             _swrContext = ffmpeg.swr_alloc();
+            if (_swrContext == null)
+                return false;
             
             // Set input options
             AVChannelLayout inChLayout = _audioCodecContext->ch_layout;
-            ffmpeg.av_opt_set_chlayout(_swrContext, "in_chlayout", &inChLayout, 0);
-            ffmpeg.av_opt_set_int(_swrContext, "in_sample_rate", sampleRate, 0);
-            ffmpeg.av_opt_set_sample_fmt(_swrContext, "in_sample_fmt", _audioCodecContext->sample_fmt, 0);
+            var optionResult = ffmpeg.av_opt_set_chlayout(_swrContext, "in_chlayout", &inChLayout, 0);
+            optionResult |= ffmpeg.av_opt_set_int(_swrContext, "in_sample_rate", sampleRate, 0);
+            optionResult |= ffmpeg.av_opt_set_sample_fmt(_swrContext, "in_sample_fmt", _audioCodecContext->sample_fmt, 0);
             
             // Set output options - stereo S16 for OpenAL
             AVChannelLayout outChLayout;
             ffmpeg.av_channel_layout_default(&outChLayout, 2); // Stereo
-            ffmpeg.av_opt_set_chlayout(_swrContext, "out_chlayout", &outChLayout, 0);
-            ffmpeg.av_opt_set_int(_swrContext, "out_sample_rate", sampleRate, 0);
-            ffmpeg.av_opt_set_sample_fmt(_swrContext, "out_sample_fmt", AVSampleFormat.AV_SAMPLE_FMT_S16, 0);
+            optionResult |= ffmpeg.av_opt_set_chlayout(_swrContext, "out_chlayout", &outChLayout, 0);
+            optionResult |= ffmpeg.av_opt_set_int(_swrContext, "out_sample_rate", sampleRate, 0);
+            optionResult |= ffmpeg.av_opt_set_sample_fmt(_swrContext, "out_sample_fmt", AVSampleFormat.AV_SAMPLE_FMT_S16, 0);
             
-            if (ffmpeg.swr_init(_swrContext) < 0)
+            if (optionResult < 0 || ffmpeg.swr_init(_swrContext) < 0)
             {
                 Debug.WriteLine("[FFmpegMediaPlayer] Failed to initialize SwrContext");
                 var ctx = _swrContext;
                 ffmpeg.swr_free(&ctx);
                 _swrContext = null;
+                return false;
             }
             else
             {
@@ -687,14 +1035,34 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     {
         lock (_lock)
         {
-            if (_formatContext == null) return;
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+            if (_isClosing || _formatContext == null) return;
+
+            if (_playbackThread is { IsAlive: false })
+            {
+                _playbackThread = null;
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+            }
+
+            if (_state == PlaybackState.Ended)
+            {
+                ffmpeg.av_seek_frame(_formatContext, -1, 0, ffmpeg.AVSEEK_FLAG_BACKWARD);
+                if (_videoCodecContext != null)
+                    ffmpeg.avcodec_flush_buffers(_videoCodecContext);
+                if (_audioCodecContext != null)
+                    ffmpeg.avcodec_flush_buffers(_audioCodecContext);
+                _position = 0;
+                _needsResync = true;
+            }
 
             if (_isPaused)
             {
                 _isPaused = false;
                 _audioPlayer?.Resume();
                 _logger.Log("FFmpegMediaPlayer", "Resume", new { Position = _position });
-                Playing?.Invoke(this, EventArgs.Empty);
+                SetState(PlaybackState.Playing);
+                RaiseSynchronized(() => Playing?.Invoke(this, EventArgs.Empty));
                 return;
             }
 
@@ -716,7 +1084,8 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             };
             _playbackThread.Start(_cancellationTokenSource.Token);
 
-            Playing?.Invoke(this, EventArgs.Empty);
+            SetState(PlaybackState.Playing);
+            RaiseSynchronized(() => Playing?.Invoke(this, EventArgs.Empty));
         }
     }
 
@@ -731,7 +1100,8 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             _isPaused = true;
             _audioPlayer?.Pause();
             _logger.Log("FFmpegMediaPlayer", "Pause", new { Position = _position });
-            Paused?.Invoke(this, EventArgs.Empty);
+            SetState(PlaybackState.Paused);
+            RaiseSynchronized(() => Paused?.Invoke(this, EventArgs.Empty));
         }
     }
 
@@ -798,17 +1168,50 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     /// </summary>
     public void Stop()
     {
+        // QueueSamples can be applying bounded backpressure while holding the native
+        // decode lock. Cancel first so it can leave that wait before Stop takes _lock.
+        try
+        {
+            Volatile.Read(ref _cancellationTokenSource)?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // A concurrently completed stop already owns the cancellation source.
+        }
+
+        Thread? playbackThread;
+        CancellationTokenSource? cancellation;
+        bool shouldRaiseStopped;
+
         lock (_lock)
         {
-            if (!_isPlaying && !_isPaused) return;
+            playbackThread = _playbackThread;
+            cancellation = _cancellationTokenSource;
+            shouldRaiseStopped = _isPlaying || _isPaused || playbackThread is not null;
+            if (!shouldRaiseStopped && _formatContext == null)
+                return;
 
             _logger.Log("FFmpegMediaPlayer", "Stop", new { Position = _position });
 
-            _cancellationTokenSource?.Cancel();
-            _playbackThread?.Join(1000);
-            _playbackThread = null;
-            _cancellationTokenSource?.Dispose();
-            _cancellationTokenSource = null;
+            Interlocked.Exchange(ref _interruptRequested, 1);
+            cancellation?.Cancel();
+        }
+
+        // The playback loop takes _lock while decoding. Waiting while holding that
+        // lock deadlocks and can lead to native resources being freed under the loop.
+        if (playbackThread is not null
+            && playbackThread != Thread.CurrentThread
+            && !playbackThread.Join(TimeSpan.FromSeconds(5)))
+        {
+            throw new TimeoutException("FFmpeg playback did not stop after its I/O was interrupted.");
+        }
+
+        lock (_lock)
+        {
+            if (ReferenceEquals(_playbackThread, playbackThread))
+                _playbackThread = null;
+            if (ReferenceEquals(_cancellationTokenSource, cancellation))
+                _cancellationTokenSource = null;
 
             _isPlaying = false;
             _isPaused = false;
@@ -831,8 +1234,14 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
 
             // Ensure audio player is properly stopped and state is synchronized
             _audioPlayer?.Stop();
-            Stopped?.Invoke(this, EventArgs.Empty);
         }
+
+        cancellation?.Dispose();
+        EndIo();
+        Interlocked.Exchange(ref _interruptRequested, 0);
+        SetState(PlaybackState.Stopped);
+        if (shouldRaiseStopped)
+            RaiseSynchronized(() => Stopped?.Invoke(this, EventArgs.Empty));
     }
 
     /// <summary>
@@ -841,6 +1250,7 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     /// <param name="positionPercent">Position as a percentage (0.0 to 1.0).</param>
     public void Seek(float positionPercent)
     {
+        positionPercent = Math.Clamp(positionPercent, 0f, 1f);
         lock (_lock)
         {
             if (_formatContext == null) return;
@@ -853,7 +1263,21 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             // at or before targetTime. We then set _seekTargetPts so the decode loops
             // drop frames between the keyframe and targetSec — that's what makes seeks
             // land on the user's position instead of snapping to keyframe boundaries.
-            ffmpeg.av_seek_frame(_formatContext, -1, targetTime, ffmpeg.AVSEEK_FLAG_BACKWARD);
+            var seekResult = ffmpeg.av_seek_frame(
+                _formatContext,
+                -1,
+                targetTime,
+                ffmpeg.AVSEEK_FLAG_BACKWARD);
+            if (seekResult < 0)
+            {
+                var error = new MediaError(
+                    MediaErrorCode.PlaybackFailed,
+                    $"FFmpeg could not seek: {GetFFmpegError(seekResult)}",
+                    seekResult);
+                _lastError = error;
+                RaiseMediaFailed(error);
+                return;
+            }
 
             if (_videoCodecContext != null)
                 ffmpeg.avcodec_flush_buffers(_videoCodecContext);
@@ -883,6 +1307,20 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
                 TargetTime = targetSec
             });
         }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default) =>
+        Task.Run(Stop, cancellationToken);
+
+    public Task CloseAsync(CancellationToken cancellationToken = default) =>
+        Task.Run(Close, cancellationToken);
+
+    public Task SeekAsync(TimeSpan position, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var percent = _duration <= 0 ? 0f : (float)(position.TotalSeconds / _duration);
+        Seek(percent);
+        return Task.CompletedTask;
     }
 
 
@@ -1308,97 +1746,157 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
         _logger.Log("FFmpegMediaPlayer", "PlaybackLoopStarted", null);
 
         bool endOfFile = false;
+        bool reachedNaturalEnd = false;
+        MediaError? playbackError = null;
 
-        while (!token.IsCancellationRequested && !endOfFile)
+        try
         {
-            if (_isPaused)
+            while (!token.IsCancellationRequested && !endOfFile)
             {
-                if (_pauseStartTime == 0)
+                if (_isPaused)
                 {
-                    _pauseStartTime = stopwatch.Elapsed.TotalSeconds;
-                }
-                Thread.Sleep(10);
-                continue;
-            }
-            else
-            {
-                // Resume from pause - accumulate pause time
-                if (_pauseStartTime > 0)
-                {
-                    _totalPauseTime += stopwatch.Elapsed.TotalSeconds - _pauseStartTime;
-                    _pauseStartTime = 0;
-                }
-            }
-
-            // Process packets
-            int packetsThisIteration = 0;
-            const int maxPacketsPerIteration = 15;
-            
-            while (packetsThisIteration < maxPacketsPerIteration && !token.IsCancellationRequested && !endOfFile)
-            {
-                int readResult;
-                int streamIndex;
-                
-                lock (_lock)
-                {
-                    if (_formatContext == null || _packet == null) break;
-                    readResult = ffmpeg.av_read_frame(_formatContext, _packet);
-                    streamIndex = _packet->stream_index;
-                }
-
-                if (readResult < 0)
-                {
-                    endOfFile = true;
-                    _logger.Log("FFmpegMediaPlayer", "EndOfFile", new { ReadResult = readResult });
-                    break;
-                }
-
-                try
-                {
-                    if (streamIndex == _audioStreamIndex)
+                    if (_pauseStartTime == 0)
                     {
-                        lock (_lock)
+                        _pauseStartTime = stopwatch.Elapsed.TotalSeconds;
+                    }
+                    Thread.Sleep(10);
+                    continue;
+                }
+                else
+                {
+                    // Resume from pause - accumulate pause time
+                    if (_pauseStartTime > 0)
+                    {
+                        _totalPauseTime += stopwatch.Elapsed.TotalSeconds - _pauseStartTime;
+                        _pauseStartTime = 0;
+                    }
+                }
+
+                // Process packets
+                int packetsThisIteration = 0;
+                const int maxPacketsPerIteration = 15;
+
+                while (packetsThisIteration < maxPacketsPerIteration && !token.IsCancellationRequested && !endOfFile)
+                {
+                    int readResult;
+                    int streamIndex;
+
+                    lock (_lock)
+                    {
+                        if (_formatContext == null || _packet == null)
                         {
-                            if (_audioCodecContext != null)
+                            endOfFile = true;
+                            break;
+                        }
+                        BeginIo(token, _readTimeout);
+                        try
+                        {
+                            readResult = ffmpeg.av_read_frame(_formatContext, _packet);
+                        }
+                        finally
+                        {
+                            EndIo();
+                        }
+                        streamIndex = _packet->stream_index;
+                    }
+
+                    if (readResult < 0)
+                    {
+                        endOfFile = true;
+                        if (readResult == ffmpeg.AVERROR_EOF)
+                        {
+                            reachedNaturalEnd = true;
+                            _logger.Log("FFmpegMediaPlayer", "EndOfFile", new { ReadResult = readResult });
+                        }
+                        else if (!token.IsCancellationRequested
+                                 && Volatile.Read(ref _interruptRequested) == 0)
+                        {
+                            playbackError = Volatile.Read(ref _ioTimedOut) != 0
+                                ? new MediaError(
+                                    MediaErrorCode.Timeout,
+                                    "Media input stopped responding during playback.",
+                                    readResult)
+                                : new MediaError(
+                                    MediaErrorCode.PlaybackFailed,
+                                    $"FFmpeg playback failed: {GetFFmpegError(readResult)}",
+                                    readResult);
+                        }
+                        break;
+                    }
+
+                    try
+                    {
+                        if (streamIndex == _audioStreamIndex)
+                        {
+                            lock (_lock)
                             {
-                                ProcessAudioPacket(stopwatch, firstFramePts, ref lastAudioPts);
-                                audioPacketsProcessed++;
+                                if (_audioCodecContext != null)
+                                {
+                                    ProcessAudioPacket(
+                                        stopwatch,
+                                        firstFramePts,
+                                        ref lastAudioPts,
+                                        token,
+                                        _packet);
+                                    audioPacketsProcessed++;
+                                }
+                            }
+                        }
+                        else if (streamIndex == _videoStreamIndex)
+                        {
+                            // ProcessVideoPacket manages its own locking:
+                            // holds lock for decode/convert, releases for UI callbacks
+                            if (_videoCodecContext != null)
+                            {
+                                ProcessVideoPacket(stopwatch, ref firstFramePts, ref lastVideoPts);
+                                videoPacketsProcessed++;
                             }
                         }
                     }
-                    else if (streamIndex == _videoStreamIndex)
+                    finally
                     {
-                        // ProcessVideoPacket manages its own locking:
-                        // holds lock for decode/convert, releases for UI callbacks
-                        if (_videoCodecContext != null)
+                        lock (_lock)
                         {
-                            ProcessVideoPacket(stopwatch, ref firstFramePts, ref lastVideoPts);
-                            videoPacketsProcessed++;
+                            if (_packet != null)
+                                ffmpeg.av_packet_unref(_packet);
                         }
                     }
+
+                    packetsThisIteration++;
                 }
-                finally
+
+                // Minimal sleep only if we processed packets, to prevent CPU spinning
+                if (packetsThisIteration > 0 && !endOfFile)
                 {
-                    lock (_lock)
-                    {
-                        if (_packet != null)
-                            ffmpeg.av_packet_unref(_packet);
-                    }
+                    UpdateAudioOnlyPositionFromPlaybackClock(stopwatch);
+                    Thread.Sleep(1);
                 }
-                
-                packetsThisIteration++;
             }
-            
-            // Minimal sleep only if we processed packets, to prevent CPU spinning
-            if (packetsThisIteration > 0 && !endOfFile)
+
+            if (reachedNaturalEnd && _audioPlayer is not null)
             {
-                UpdateAudioOnlyPositionFromPlaybackClock(stopwatch);
-                Thread.Sleep(1);
+                lock (_lock)
+                {
+                    FlushAudioPipeline(stopwatch, firstFramePts, ref lastAudioPts, token);
+                    _audioPlayer?.CompleteInput();
+                }
+
+                WaitForAudioPlaybackToDrain(token, stopwatch);
             }
         }
-
-        // Reset state inside lock
-        WaitForAudioOnlyPlaybackToFinish(token, stopwatch);
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            reachedNaturalEnd = false;
+        }
+        catch (Exception ex)
+        {
+            reachedNaturalEnd = false;
+            playbackError = new MediaError(
+                MediaErrorCode.PlaybackFailed,
+                "An unexpected error stopped media playback.",
+                Exception: ex);
+            _logger.Log("FFmpegMediaPlayer", "PlaybackLoopFailed", new { Error = ex.Message });
+        }
 
         // Reset state inside lock
         lock (_lock)
@@ -1411,43 +1909,52 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             _isPlaying = false;
             _isPaused = false;
 
-            // Seek back to start so Play() can restart from the beginning
-            if (_formatContext != null)
-            {
-                ffmpeg.av_seek_frame(_formatContext, -1, 0, ffmpeg.AVSEEK_FLAG_BACKWARD);
-                if (_videoCodecContext != null)
-                    ffmpeg.avcodec_flush_buffers(_videoCodecContext);
-                if (_audioCodecContext != null)
-                    ffmpeg.avcodec_flush_buffers(_audioCodecContext);
-            }
-
-            _position = 0;
+            if (reachedNaturalEnd)
+                _position = _duration;
             _needsResync = true;
             _lastFramePts = -1;
             _seekTargetPts = -1;
 
-            _audioPlayer?.Stop();
+            try
+            {
+                _audioPlayer?.Stop();
+            }
+            catch (Exception ex)
+            {
+                playbackError ??= new MediaError(
+                    MediaErrorCode.AudioOutputUnavailable,
+                    "The audio output failed while playback was stopping.",
+                    Exception: ex);
+            }
         }
 
-        // Fire EndReached OUTSIDE lock to prevent deadlock with UI thread
-        if (_synchronizationCallback != null)
-            _synchronizationCallback(() => EndReached?.Invoke(this, EventArgs.Empty));
-        else
-            EndReached?.Invoke(this, EventArgs.Empty);
+        if (playbackError is not null)
+        {
+            _lastError = playbackError;
+            SetState(PlaybackState.Failed);
+            RaiseMediaFailed(playbackError);
+        }
+        else if (reachedNaturalEnd && !token.IsCancellationRequested)
+        {
+            SetState(PlaybackState.Ended);
+            RaiseSynchronized(() => EndReached?.Invoke(this, EventArgs.Empty));
+        }
     }
 
-    private void WaitForAudioOnlyPlaybackToFinish(CancellationToken token, Stopwatch stopwatch)
+    private void WaitForAudioPlaybackToDrain(CancellationToken token, Stopwatch stopwatch)
     {
-        if (_videoStreamIndex >= 0 || _audioPlayer == null || _duration <= 0)
+        var audioPlayer = _audioPlayer;
+        if (audioPlayer == null)
             return;
 
-        _logger.Log("FFmpegMediaPlayer", "AudioOnlyDrainStarted", new
+        _logger.Log("FFmpegMediaPlayer", "AudioDrainStarted", new
         {
             Duration = _duration,
-            AudioStartPts = _audioStartPts
+            AudioStartPts = _audioStartPts,
+            HasVideo = _videoStreamIndex >= 0
         });
 
-        while (!token.IsCancellationRequested)
+        while (!token.IsCancellationRequested && !audioPlayer.IsDrained)
         {
             if (_isPaused)
             {
@@ -1466,27 +1973,28 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
 
             var playedPosition = UpdateAudioOnlyPositionFromPlaybackClock(stopwatch);
 
-            if (playedPosition >= _duration - 0.05)
-                break;
+            if (_videoStreamIndex < 0)
+                UpdateAudioOnlyPositionFromPlaybackClock(stopwatch);
 
-            Thread.Sleep(50);
+            Thread.Sleep(10);
         }
 
-        _logger.Log("FFmpegMediaPlayer", "AudioOnlyDrainCompleted", new
+        _logger.Log("FFmpegMediaPlayer", "AudioDrainCompleted", new
         {
             Position = _position,
-            ElapsedWallTime = stopwatch.Elapsed.TotalSeconds - _playbackStartWallTime - _totalPauseTime
+            IsDrained = audioPlayer.IsDrained
         });
     }
 
     private double UpdateAudioOnlyPositionFromPlaybackClock(Stopwatch stopwatch)
     {
-        if (_videoStreamIndex >= 0 || _duration <= 0 || _playbackStartWallTime <= 0)
+        if (_videoStreamIndex >= 0 || _audioPlayer == null)
             return _position;
 
-        var elapsedWall = stopwatch.Elapsed.TotalSeconds - _playbackStartWallTime - _totalPauseTime;
-        var playedPosition = _startTime + Math.Max(0, elapsedWall);
-        _position = Math.Clamp(playedPosition, 0, _duration);
+        var playedPosition = _audioStartPts + Math.Max(0, _audioPlayer.GetPlaybackTime());
+        _position = _duration > 0
+            ? Math.Clamp(playedPosition, 0, _duration)
+            : Math.Max(0, playedPosition);
         var positionSnapshot = Position;
 
         if (_synchronizationCallback != null)
@@ -1664,7 +2172,12 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     }
 
 
-    private void ProcessAudioPacket(Stopwatch stopwatch, double firstFramePts, ref double lastAudioPts)
+    private void ProcessAudioPacket(
+        Stopwatch stopwatch,
+        double firstFramePts,
+        ref double lastAudioPts,
+        CancellationToken cancellationToken,
+        AVPacket* packet)
     {
         if (_audioPlayer == null)
         {
@@ -1672,7 +2185,7 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             _logger.Log("FFmpegMediaPlayer", "ProcessAudioPacketFailed", new { Reason = "AudioPlayer is null" });
             return;
         }
-        if (ffmpeg.avcodec_send_packet(_audioCodecContext, _packet) < 0)
+        if (ffmpeg.avcodec_send_packet(_audioCodecContext, packet) < 0)
         {
             Debug.WriteLine("[FFmpegMediaPlayer] ProcessAudioPacket: avcodec_send_packet failed");
             _logger.Log("FFmpegMediaPlayer", "ProcessAudioPacketFailed", new { Reason = "avcodec_send_packet failed" });
@@ -1686,6 +2199,7 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
         {
             while (ffmpeg.avcodec_receive_frame(_audioCodecContext, tempFrame) >= 0)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var samples = tempFrame->nb_samples;
                 var channels = _audioCodecContext->ch_layout.nb_channels;
                 var sampleRate = _audioCodecContext->sample_rate;
@@ -1761,7 +2275,10 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
                             // Queue the S16 samples directly
                             // convertedSamples is per-channel, so for stereo we have convertedSamples * 2 total samples
                             // QueueSamplesS16 expects total sample count (stereo interleaved: L, R, L, R, ...)
-                            _audioPlayer.QueueSamplesS16(outPtr, convertedSamples * 2);
+                            _audioPlayer.QueueSamplesS16(
+                                outPtr,
+                                convertedSamples * 2,
+                                cancellationToken);
                             _logger.Log("FFmpegMediaPlayer", "AudioQueued", new 
                             { 
                                 InputSamples = samples,
@@ -1775,18 +2292,15 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
                 }
                 else
                 {
-                    // Fallback to manual conversion
-                    var floatBuffer = new float[samples * 2]; // Output stereo
-                    var format2 = (AVSampleFormat)tempFrame->format;
-                    ConvertAudioSamples(tempFrame, floatBuffer, samples, channels, format2);
-                    _audioPlayer.QueueSamples(floatBuffer);
-                    _logger.Log("FFmpegMediaPlayer", "AudioQueued", new 
-                    { 
+                    // A configured resampler is required for safe stereo output. The old
+                    // manual fallback wrote input channel counts into a stereo buffer.
+                    _logger.Log("FFmpegMediaPlayer", "AudioFrameDropped", new
+                    {
+                        Reason = "Resampler unavailable",
                         Samples = samples,
-                        Channels = channels,
-                        AudioTime = pts != ffmpeg.AV_NOPTS_VALUE ? pts * _audioTimeBase.num / (double)_audioTimeBase.den : 0,
-                        Format = format2.ToString()
+                        Channels = channels
                     });
+                    return;
                 }
             }
         }
@@ -1930,10 +2444,103 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     /// </summary>
     public void Close()
     {
-        Stop();
-        lock (_lock)
+        if (_isDisposed)
+            return;
+
+        CancelPendingOpen();
+        _openGate.Wait();
+        Interlocked.Exchange(ref _openGateHeld, 1);
+        MediaSourceSession? session = null;
+        try
         {
-            CloseInternal();
+            if (_isDisposed)
+                return;
+
+            session = CloseWhileOpenGateHeld();
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _openGateHeld, 0);
+            _openGate.Release();
+        }
+
+        session?.Dispose();
+        SetState(PlaybackState.Closed);
+    }
+
+    private MediaSourceSession? CloseWhileOpenGateHeld()
+    {
+        lock (_lock)
+            _isClosing = true;
+
+        try
+        {
+            Stop();
+            lock (_lock)
+            {
+                CloseInternal();
+                var session = _mediaSession;
+                _mediaSession = null;
+                _mediaInfo = null;
+                _mediaSource = null;
+                return session;
+            }
+        }
+        finally
+        {
+            lock (_lock)
+                _isClosing = false;
+        }
+    }
+
+    private void FlushAudioPipeline(
+        Stopwatch stopwatch,
+        double firstFramePts,
+        ref double lastAudioPts,
+        CancellationToken cancellationToken)
+    {
+        if (_audioPlayer == null || _audioCodecContext == null)
+            return;
+
+        // A null packet tells FFmpeg to emit delayed codec frames.
+        ProcessAudioPacket(
+            stopwatch,
+            firstFramePts,
+            ref lastAudioPts,
+            cancellationToken,
+            null);
+
+        if (_swrContext == null)
+            return;
+
+        var sampleRate = _audioCodecContext->sample_rate;
+        var outputPlanes = stackalloc byte*[1];
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var delayedSamples = ffmpeg.swr_get_delay(_swrContext, sampleRate);
+            if (delayedSamples <= 0)
+                break;
+
+            var outputCapacity = checked((int)Math.Min(delayedSamples, int.MaxValue / 2));
+            var output = new short[outputCapacity * 2];
+            fixed (short* outputPointer = output)
+            {
+                outputPlanes[0] = (byte*)outputPointer;
+                var convertedSamples = ffmpeg.swr_convert(
+                    _swrContext,
+                    outputPlanes,
+                    outputCapacity,
+                    null,
+                    0);
+                if (convertedSamples <= 0)
+                    break;
+
+                _audioPlayer.QueueSamplesS16(
+                    outputPointer,
+                    convertedSamples * 2,
+                    cancellationToken);
+            }
         }
     }
 
@@ -1942,12 +2549,73 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_isDisposed) return;
-        _isDisposed = true;
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+            return;
 
+        _isDisposed = true;
         _logger.Log("FFmpegMediaPlayer", "Dispose", null);
-        Close();
-        _logger.Dispose();
+        CancelPendingOpen();
+
+        // A source provider is user-extensible and may not observe cancellation.
+        // Keep synchronous UI teardown bounded; final cleanup continues as soon as
+        // the in-flight open releases the serialization gate.
+        if (_openGate.Wait(TimeSpan.FromMilliseconds(100)))
+            CompleteDisposeWithOpenGateHeld();
+        else
+            _ = Task.Run(CompleteDisposeWhenOpenGateAvailable);
+    }
+
+    /// <summary>
+    /// Disposes the player and asynchronously waits until an in-flight source open
+    /// has released its resources.
+    /// </summary>
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return new ValueTask(_disposeCompletion.Task);
+    }
+
+    private void CompleteDisposeWhenOpenGateAvailable()
+    {
+        try
+        {
+            _openGate.Wait();
+            CompleteDisposeWithOpenGateHeld();
+        }
+        catch (Exception ex)
+        {
+            _disposeCompletion.TrySetException(ex);
+        }
+    }
+
+    private void CompleteDisposeWithOpenGateHeld()
+    {
+        Interlocked.Exchange(ref _openGateHeld, 1);
+        MediaSourceSession? session = null;
+        try
+        {
+            session = CloseWhileOpenGateHeld();
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _openGateHeld, 0);
+            _openGate.Release();
+        }
+
+        try
+        {
+            session?.Dispose();
+            SetState(PlaybackState.Disposed);
+            if (_interruptHandle.IsAllocated)
+                _interruptHandle.Free();
+            _logger.Dispose();
+            Volatile.Write(ref _disposeState, 2);
+            _disposeCompletion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            _disposeCompletion.TrySetException(ex);
+        }
     }
 }
 

--- a/FFmpegVideoPlayer.Core/FFmpegVideoPlayer.Core.csproj
+++ b/FFmpegVideoPlayer.Core/FFmpegVideoPlayer.Core.csproj
@@ -2,16 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
     
     <!-- NuGet Package Properties -->
     <PackageId>FFmpegVideoPlayer.Core</PackageId>
     <AssemblyName>FFmpegVideoPlayer.Core</AssemblyName>
     <RootNamespace>FFmpegVideoPlayer.Core</RootNamespace>
-    <Version>2.7.0</Version>
     <Authors>jojomondag</Authors>
     <Company>jojomondag</Company>
     <Description>Core FFmpeg video player logic without UI dependencies. Use this package for non-Avalonia projects or custom UI implementations.</Description>
@@ -28,48 +25,9 @@
   <ItemGroup>
     <!-- FFmpeg bindings for .NET - cross-platform including ARM64 -->
     <!-- Using version 8.0.0 which expects FFmpeg 8.x libraries (libavcodec.62) -->
-    <PackageReference Include="FFmpeg.AutoGen" Version="8.0.0" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="8.0.0.1" />
+    <PackageReference Include="YoutubeExplode" Version="6.6.0" />
   </ItemGroup>
 
-  <!-- Include README and images in package -->
-  <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
-  </ItemGroup>
-
-  <!-- 
-    Native FFmpeg libraries - using contentFiles for automatic deployment.
-    The runtimes folder structure follows .NET conventions for native libraries.
-  -->
-  
-  <!-- Windows x64 native libraries -->
-  <ItemGroup>
-    <None Include="runtimes/win-x64/native/*.dll" Pack="true" PackagePath="runtimes/win-x64/native/" Condition="Exists('runtimes/win-x64/native/')" />
-  </ItemGroup>
-  
-  <!-- macOS ARM64 native libraries -->
-  <ItemGroup>
-    <None Include="runtimes/osx-arm64/native/*.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/" Condition="Exists('runtimes/osx-arm64/native/')" />
-  </ItemGroup>
-  
-  <!-- macOS x64 native libraries (if available) -->
-  <ItemGroup Condition="Exists('runtimes/osx-x64/native/')">
-    <None Include="runtimes/osx-x64/native/*.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/" />
-  </ItemGroup>
-  
-  <!-- Linux x64 native libraries (if available) -->
-  <ItemGroup Condition="Exists('runtimes/linux-x64/native/')">
-    <None Include="runtimes/linux-x64/native/*.so*" Pack="true" PackagePath="runtimes/linux-x64/native/" />
-  </ItemGroup>
-
-  <!-- Copy native libraries to output for local development/testing -->
-  <Target Name="CopyBundledFFmpeg" AfterTargets="Build">
-    <ItemGroup>
-      <NativeRuntimeFiles Include="runtimes/**/*.*" Exclude="runtimes/README.md" />
-    </ItemGroup>
-    <Copy SourceFiles="@(NativeRuntimeFiles)"
-          DestinationFiles="@(NativeRuntimeFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(NativeRuntimeFiles)' != ''" />
-  </Target>
 </Project>
 

--- a/FFmpegVideoPlayer.Core/IAudioPlayer.cs
+++ b/FFmpegVideoPlayer.Core/IAudioPlayer.cs
@@ -42,9 +42,46 @@ public interface IAudioPlayer : IDisposable
     unsafe void QueueSamplesS16(short* samples, int sampleCount);
 
     /// <summary>
+    /// Queues pre-converted S16 samples, waiting for bounded backend capacity when needed.
+    /// Implementations written against earlier versions remain compatible through this
+    /// default implementation.
+    /// </summary>
+    unsafe void QueueSamplesS16(short* samples, int sampleCount, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        QueueSamplesS16(samples, sampleCount);
+    }
+
+    /// <summary>
     /// Queues float samples (will be converted internally if needed).
     /// </summary>
     /// <param name="samples">Float samples array (stereo interleaved).</param>
     void QueueSamples(float[] samples);
+
+    /// <summary>
+    /// Queues float samples, waiting for bounded backend capacity when needed.
+    /// Implementations written against earlier versions remain compatible through this
+    /// default implementation.
+    /// </summary>
+    void QueueSamples(float[] samples, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        QueueSamples(samples);
+    }
+
+    /// <summary>
+    /// Signals that no more samples will be queued for the current playback generation.
+    /// Backends can use this to start and drain clips shorter than their normal pre-roll.
+    /// </summary>
+    void CompleteInput()
+    {
+    }
+
+    /// <summary>
+    /// Gets whether all completed input has left the playback pipeline.
+    /// The compatibility default reflects that legacy implementations do not expose a
+    /// drainable pipeline.
+    /// </summary>
+    bool IsDrained => true;
 }
 

--- a/FFmpegVideoPlayer.Core/InternalsVisibleTo.cs
+++ b/FFmpegVideoPlayer.Core/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FFmpegVideoPlayer.Tests")]

--- a/FFmpegVideoPlayer.Core/Media/LoopbackMediaSession.cs
+++ b/FFmpegVideoPlayer.Core/Media/LoopbackMediaSession.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FFmpegVideoPlayer.Core;
+
+/// <summary>
+/// Exposes a small set of media resources on a random loopback-only HTTP endpoint.
+/// FFmpeg can then use ordinary byte-range requests while the backing streams remain
+/// remote and are never written to disk.
+/// </summary>
+public sealed class LoopbackMediaSession : IAsyncDisposable, IDisposable
+{
+    private const int DefaultMaximumHeaderBytes = 32 * 1024;
+    private const int DefaultMaximumConnections = 16;
+    private static readonly TimeSpan DefaultHeaderTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan DefaultUpstreamOpenTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultReadIdleTimeout = TimeSpan.FromSeconds(30);
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly TcpListener _listener;
+    private readonly IReadOnlyDictionary<string, MediaResource> _resources;
+    private readonly string _routePrefix;
+    private readonly TimeSpan _headerTimeout;
+    private readonly TimeSpan _upstreamOpenTimeout;
+    private readonly TimeSpan _readIdleTimeout;
+    private readonly int _maximumHeaderBytes;
+    private readonly SemaphoreSlim _connectionLimit;
+    private readonly ConcurrentDictionary<int, Task> _requestTasks = new();
+    private readonly Task _acceptTask;
+    private int _nextRequestId;
+    private int _disposed;
+
+    public LoopbackMediaSession(
+        string primaryFileName,
+        IEnumerable<MediaResource> resources,
+        TimeSpan? headerTimeout = null,
+        TimeSpan? upstreamOpenTimeout = null,
+        TimeSpan? readIdleTimeout = null,
+        int maximumHeaderBytes = DefaultMaximumHeaderBytes,
+        int maximumConnections = DefaultMaximumConnections)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(primaryFileName);
+        ArgumentNullException.ThrowIfNull(resources);
+        if (maximumHeaderBytes < 1024)
+            throw new ArgumentOutOfRangeException(nameof(maximumHeaderBytes));
+        if (maximumConnections <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumConnections));
+
+        _headerTimeout = ValidateTimeout(headerTimeout ?? DefaultHeaderTimeout, nameof(headerTimeout));
+        _upstreamOpenTimeout = ValidateTimeout(
+            upstreamOpenTimeout ?? DefaultUpstreamOpenTimeout,
+            nameof(upstreamOpenTimeout));
+        _readIdleTimeout = ValidateTimeout(readIdleTimeout ?? DefaultReadIdleTimeout, nameof(readIdleTimeout));
+        _maximumHeaderBytes = maximumHeaderBytes;
+        _connectionLimit = new SemaphoreSlim(maximumConnections, maximumConnections);
+
+        _resources = resources
+            .ToDictionary(resource => resource.FileName, StringComparer.Ordinal);
+        if (!_resources.ContainsKey(primaryFileName))
+            throw new ArgumentException("The primary file must be present in resources.", nameof(resources));
+        _routePrefix = "/" + Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant() + "/";
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+
+        var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        FileName = primaryFileName;
+        PlaybackUrl =
+            $"http://127.0.0.1:{port.ToString(CultureInfo.InvariantCulture)}{_routePrefix}{Uri.EscapeDataString(primaryFileName)}";
+        _acceptTask = AcceptRequestsAsync(_shutdown.Token);
+    }
+
+    /// <summary>Creates a DASH manifest session without writing media to disk.</summary>
+    public LoopbackMediaSession(
+        string manifestFileName,
+        string manifest,
+        IEnumerable<MediaResource> mediaResources,
+        TimeSpan? headerTimeout = null,
+        TimeSpan? upstreamOpenTimeout = null,
+        TimeSpan? readIdleTimeout = null)
+        : this(
+            manifestFileName,
+            AppendManifest(manifestFileName, manifest, mediaResources),
+            headerTimeout,
+            upstreamOpenTimeout,
+            readIdleTimeout)
+    {
+    }
+
+    public string PlaybackUrl { get; }
+    public string FileName { get; }
+
+    public void Dispose() => DisposeCoreAsync().GetAwaiter().GetResult();
+
+    public ValueTask DisposeAsync() => new(DisposeCoreAsync());
+
+    private async Task DisposeCoreAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _shutdown.Cancel();
+        _listener.Stop();
+        await ObserveShutdownAsync(_acceptTask).ConfigureAwait(false);
+        await Task.WhenAll(_requestTasks.Values.Select(ObserveShutdownAsync)).ConfigureAwait(false);
+        _connectionLimit.Dispose();
+        _shutdown.Dispose();
+    }
+
+    private async Task AcceptRequestsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await _connectionLimit.WaitAsync(cancellationToken).ConfigureAwait(false);
+                TcpClient? client = null;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                    var requestId = Interlocked.Increment(ref _nextRequestId);
+                    var requestTask = HandleTrackedRequestAsync(client, cancellationToken);
+                    client = null; // Ownership transferred to the request task.
+                    _requestTasks[requestId] = requestTask;
+                    _ = requestTask.ContinueWith(
+                        completedTask =>
+                        {
+                            _requestTasks.TryRemove(requestId, out var removedTask);
+                            _ = completedTask;
+                            _ = removedTask;
+                        },
+                        CancellationToken.None,
+                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+                catch
+                {
+                    client?.Dispose();
+                    _connectionLimit.Release();
+                    throw;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError($"[LoopbackMediaSession] Accept failed: {ex}");
+        }
+    }
+
+    private async Task HandleTrackedRequestAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await HandleRequestAsync(client, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _connectionLimit.Release();
+        }
+    }
+
+    private async Task HandleRequestAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            var timeoutPhase = "request headers";
+            try
+            {
+                client.NoDelay = true;
+                await using var network = client.GetStream();
+                using var reader = new StreamReader(
+                    network,
+                    Encoding.ASCII,
+                    detectEncodingFromByteOrderMarks: false,
+                    bufferSize: 1024,
+                    leaveOpen: true);
+
+                string requestLine;
+                var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                using (var headerTimeout = CreateTimeout(cancellationToken, _headerTimeout))
+                {
+                    requestLine = await reader.ReadLineAsync(headerTimeout.Token).ConfigureAwait(false) ?? string.Empty;
+                    if (string.IsNullOrWhiteSpace(requestLine))
+                        return;
+
+                    var headerBytes = requestLine.Length + 2;
+
+                    while (await reader.ReadLineAsync(headerTimeout.Token).ConfigureAwait(false) is { Length: > 0 } line)
+                    {
+                        headerBytes += line.Length + 2;
+                        if (headerBytes > _maximumHeaderBytes)
+                        {
+                            await WriteStatusAsync(network, 431, "Request Header Fields Too Large", cancellationToken)
+                                .ConfigureAwait(false);
+                            return;
+                        }
+
+                        var separator = line.IndexOf(':');
+                        if (separator > 0)
+                            headers[line[..separator].Trim()] = line[(separator + 1)..].Trim();
+                    }
+                }
+
+                var requestParts = requestLine.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+                if (requestParts.Length < 2 || requestParts[0] is not ("GET" or "HEAD"))
+                {
+                    await WriteStatusAsync(network, 405, "Method Not Allowed", cancellationToken)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                var requestTarget = requestParts[1];
+                var queryIndex = requestTarget.IndexOf('?');
+                var requestPath = Uri.UnescapeDataString(
+                    queryIndex >= 0 ? requestTarget[..queryIndex] : requestTarget);
+
+                if (!requestPath.StartsWith(_routePrefix, StringComparison.Ordinal)
+                    || !_resources.TryGetValue(requestPath[_routePrefix.Length..], out var resource))
+                {
+                    await WriteStatusAsync(network, 404, "Not Found", cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                var range = ParseRange(headers.GetValueOrDefault("Range"), resource.Length);
+                if (range is null)
+                {
+                    await WriteRangeNotSatisfiableAsync(network, resource.Length, cancellationToken)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                var (start, end, isPartial) = range.Value;
+                if (requestParts[0] == "HEAD")
+                {
+                    await WriteResourceHeadersAsync(
+                            network,
+                            resource.ContentType,
+                            resource.Length,
+                            start,
+                            end,
+                            isPartial,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                timeoutPhase = "upstream media open";
+                await using var source = await OpenResourceAsync(
+                        resource,
+                        _upstreamOpenTimeout,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!source.CanSeek)
+                    throw new InvalidOperationException("Media stream must support seeking.");
+
+                source.Position = start;
+                await WriteResourceHeadersAsync(
+                        network,
+                        resource.ContentType,
+                        resource.Length,
+                        start,
+                        end,
+                        isPartial,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                timeoutPhase = "upstream media read";
+                await CopyExactlyAsync(
+                        source,
+                        network,
+                        end - start + 1,
+                        _readIdleTimeout,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (OperationCanceledException)
+            {
+                Trace.TraceWarning($"[LoopbackMediaSession] Request timed out during {timeoutPhase}.");
+            }
+            catch (IOException)
+            {
+                // FFmpeg closes probe/range connections as soon as it has enough data.
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError($"[LoopbackMediaSession] Request failed: {ex}");
+            }
+        }
+    }
+
+    private static IEnumerable<MediaResource> AppendManifest(
+        string manifestFileName,
+        string manifest,
+        IEnumerable<MediaResource> mediaResources)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifestFileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifest);
+        ArgumentNullException.ThrowIfNull(mediaResources);
+        var manifestBytes = Encoding.UTF8.GetBytes(manifest);
+        return mediaResources.Append(new MediaResource(
+            manifestFileName,
+            "application/dash+xml",
+            manifestBytes.LongLength,
+            _ => ValueTask.FromResult<Stream>(new MemoryStream(manifestBytes, writable: false))));
+    }
+
+    private static async Task ObserveShutdownAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private static TimeSpan ValidateTimeout(TimeSpan timeout, string parameterName)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(parameterName, "Timeout must be greater than zero.");
+
+        return timeout;
+    }
+
+    private static CancellationTokenSource CreateTimeout(
+        CancellationToken cancellationToken,
+        TimeSpan timeout)
+    {
+        var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeout);
+        return timeoutSource;
+    }
+
+    private static async ValueTask<Stream> OpenResourceAsync(
+        MediaResource resource,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var openTimeout = CreateTimeout(cancellationToken, timeout);
+        var openTask = resource.OpenAsync(openTimeout.Token).AsTask();
+        try
+        {
+            return await openTask.WaitAsync(openTimeout.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            _ = DisposeLateStreamAsync(openTask);
+            throw;
+        }
+    }
+
+    private static async Task DisposeLateStreamAsync(Task<Stream> openTask)
+    {
+        try
+        {
+            await using var stream = await openTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The request already ended. Observe any late fault from a non-cooperative
+            // resource factory, and dispose a stream if it completes after the timeout.
+        }
+    }
+
+    private static (long Start, long End, bool IsPartial)? ParseRange(string? value, long length)
+    {
+        if (length <= 0)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return (0, length - 1, false);
+
+        if (!value.StartsWith("bytes=", StringComparison.OrdinalIgnoreCase)
+            || value.Contains(',', StringComparison.Ordinal))
+            return null;
+
+        var parts = value[6..].Split('-', 2);
+        if (parts.Length != 2)
+            return null;
+
+        long start;
+        long end;
+        if (parts[0].Length == 0)
+        {
+            if (!long.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var suffixLength)
+                || suffixLength <= 0)
+                return null;
+
+            suffixLength = Math.Min(suffixLength, length);
+            start = length - suffixLength;
+            end = length - 1;
+        }
+        else
+        {
+            if (!long.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out start)
+                || start < 0
+                || start >= length)
+                return null;
+
+            if (parts[1].Length == 0)
+            {
+                end = length - 1;
+            }
+            else if (!long.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out end)
+                     || end < start)
+            {
+                return null;
+            }
+
+            end = Math.Min(end, length - 1);
+        }
+
+        return (start, end, true);
+    }
+
+    private static async Task WriteResourceHeadersAsync(
+        Stream destination,
+        string contentType,
+        long totalLength,
+        long start,
+        long end,
+        bool isPartial,
+        CancellationToken cancellationToken)
+    {
+        var status = isPartial ? "206 Partial Content" : "200 OK";
+        var contentRange = isPartial
+            ? $"Content-Range: bytes {start.ToString(CultureInfo.InvariantCulture)}-{end.ToString(CultureInfo.InvariantCulture)}/{totalLength.ToString(CultureInfo.InvariantCulture)}\r\n"
+            : string.Empty;
+        var header =
+            $"HTTP/1.1 {status}\r\n" +
+            $"Content-Type: {contentType}\r\n" +
+            $"Content-Length: {(end - start + 1).ToString(CultureInfo.InvariantCulture)}\r\n" +
+            contentRange +
+            "Accept-Ranges: bytes\r\n" +
+            "Cache-Control: no-store\r\n" +
+            "Connection: close\r\n\r\n";
+
+        await destination.WriteAsync(Encoding.ASCII.GetBytes(header), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteRangeNotSatisfiableAsync(
+        Stream destination,
+        long length,
+        CancellationToken cancellationToken)
+    {
+        var header =
+            "HTTP/1.1 416 Range Not Satisfiable\r\n" +
+            $"Content-Range: bytes */{length.ToString(CultureInfo.InvariantCulture)}\r\n" +
+            "Content-Length: 0\r\n" +
+            "Connection: close\r\n\r\n";
+        await destination.WriteAsync(Encoding.ASCII.GetBytes(header), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteStatusAsync(
+        Stream destination,
+        int statusCode,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var header =
+            $"HTTP/1.1 {statusCode.ToString(CultureInfo.InvariantCulture)} {reason}\r\n" +
+            "Content-Length: 0\r\n" +
+            "Connection: close\r\n\r\n";
+        await destination.WriteAsync(Encoding.ASCII.GetBytes(header), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task CopyExactlyAsync(
+        Stream source,
+        Stream destination,
+        long bytesToCopy,
+        TimeSpan readIdleTimeout,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[128 * 1024];
+        while (bytesToCopy > 0)
+        {
+            var requested = (int)Math.Min(buffer.Length, bytesToCopy);
+            int read;
+            using (var readTimeout = CreateTimeout(cancellationToken, readIdleTimeout))
+            {
+                var readTask = source.ReadAsync(buffer.AsMemory(0, requested), readTimeout.Token).AsTask();
+                try
+                {
+                    read = await readTask.WaitAsync(readTimeout.Token).ConfigureAwait(false);
+                }
+                catch
+                {
+                    _ = ObserveLateReadAsync(readTask);
+                    throw;
+                }
+            }
+
+            if (read == 0)
+                throw new EndOfStreamException("Media stream ended before the requested range was complete.");
+
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            bytesToCopy -= read;
+        }
+    }
+
+    private static async Task ObserveLateReadAsync(Task<int> readTask)
+    {
+        try
+        {
+            await readTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The connection has already closed; only observe a late read failure.
+        }
+    }
+}

--- a/FFmpegVideoPlayer.Core/Media/MediaSource.cs
+++ b/FFmpegVideoPlayer.Core/Media/MediaSource.cs
@@ -1,0 +1,249 @@
+using System.Collections.ObjectModel;
+
+namespace FFmpegVideoPlayer.Core;
+
+/// <summary>
+/// Describes how media should be opened. A source is reusable; each open creates a
+/// private session whose lifetime is owned by <see cref="FFmpegMediaPlayer"/>.
+/// </summary>
+public sealed class MediaSource
+{
+    private readonly Func<CancellationToken, ValueTask<MediaSourceSession>> _openSessionAsync;
+
+    private MediaSource(
+        string displayName,
+        MediaSourceKind kind,
+        Func<CancellationToken, ValueTask<MediaSourceSession>> openSessionAsync)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        DisplayName = displayName;
+        Kind = kind;
+        _openSessionAsync = openSessionAsync ?? throw new ArgumentNullException(nameof(openSessionAsync));
+    }
+
+    /// <summary>Gets a safe display name for diagnostics and UI.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Gets the source kind.</summary>
+    public MediaSourceKind Kind { get; }
+
+    /// <summary>Creates a source from a local path, HTTP(S) URI, or supported provider URL.</summary>
+    public static MediaSource FromLocation(string location)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(location);
+
+        if (YouTubeMediaSourceResolver.IsSupportedUrl(location))
+            return YouTubeMediaSourceResolver.Instance.CreateSource(location);
+
+        if (Uri.TryCreate(location, UriKind.Absolute, out var uri))
+            return uri.IsFile ? FromPath(uri.LocalPath) : FromUri(uri);
+
+        return FromPath(location);
+    }
+
+    /// <summary>Creates a source backed by a local media file.</summary>
+    public static MediaSource FromPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var fullPath = Path.GetFullPath(path);
+        return new MediaSource(
+            Path.GetFileName(fullPath),
+            MediaSourceKind.File,
+            _ =>
+            {
+                if (!File.Exists(fullPath))
+                    throw new FileNotFoundException("The media file does not exist.", fullPath);
+                return ValueTask.FromResult(new MediaSourceSession(fullPath));
+            });
+    }
+
+    /// <summary>Creates a direct FFmpeg URI source with optional HTTP headers and FFmpeg options.</summary>
+    public static MediaSource FromUri(
+        Uri uri,
+        IReadOnlyDictionary<string, string>? headers = null,
+        IReadOnlyDictionary<string, string>? ffmpegOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+        if (!uri.IsAbsoluteUri)
+            throw new ArgumentException("Media URI must be absolute.", nameof(uri));
+
+        var safeName = Path.GetFileName(uri.LocalPath);
+        if (string.IsNullOrWhiteSpace(safeName))
+            safeName = uri.Host;
+
+        var headerCopy = CopyAndValidate(headers, nameof(headers), rejectNewLines: true);
+        var optionCopy = CopyAndValidate(ffmpegOptions, nameof(ffmpegOptions), rejectNewLines: false);
+        return new MediaSource(
+            safeName,
+            MediaSourceKind.Uri,
+            _ => ValueTask.FromResult(new MediaSourceSession(uri.AbsoluteUri, headerCopy, optionCopy)));
+    }
+
+    /// <summary>
+    /// Creates a seekable stream source. The stream is exposed through a private loopback
+    /// range endpoint because FFmpeg can seek it reliably without temporary files.
+    /// </summary>
+    public static MediaSource FromSeekableStream(
+        string fileName,
+        string contentType,
+        long length,
+        Func<CancellationToken, ValueTask<Stream>> openAsync) =>
+        FromResources(fileName, [new MediaResource(fileName, contentType, length, openAsync)]);
+
+    /// <summary>Creates a source from a manifest and one or more seekable media resources.</summary>
+    public static MediaSource FromManifest(
+        string manifestFileName,
+        string manifestContentType,
+        ReadOnlyMemory<byte> manifest,
+        IEnumerable<MediaResource> resources)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifestFileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifestContentType);
+        if (manifest.IsEmpty)
+            throw new ArgumentException("Manifest content cannot be empty.", nameof(manifest));
+
+        var manifestBytes = manifest.ToArray();
+        var allResources = resources
+            .Append(new MediaResource(
+                manifestFileName,
+                manifestContentType,
+                manifestBytes.LongLength,
+                _ => ValueTask.FromResult<Stream>(new MemoryStream(manifestBytes, writable: false))))
+            .ToArray();
+        return FromResources(manifestFileName, allResources, MediaSourceKind.Manifest);
+    }
+
+    internal static MediaSource FromSessionFactory(
+        string displayName,
+        MediaSourceKind kind,
+        Func<CancellationToken, ValueTask<MediaSourceSession>> openSessionAsync) =>
+        new(displayName, kind, openSessionAsync);
+
+    internal ValueTask<MediaSourceSession> OpenSessionAsync(CancellationToken cancellationToken) =>
+        _openSessionAsync(cancellationToken);
+
+    private static MediaSource FromResources(
+        string primaryFileName,
+        IEnumerable<MediaResource> resources,
+        MediaSourceKind kind = MediaSourceKind.Stream)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(primaryFileName);
+        var resourceArray = resources?.ToArray() ?? throw new ArgumentNullException(nameof(resources));
+        if (resourceArray.Length == 0)
+            throw new ArgumentException("At least one media resource is required.", nameof(resources));
+
+        return new MediaSource(
+            primaryFileName,
+            kind,
+            _ =>
+            {
+                var session = new LoopbackMediaSession(primaryFileName, resourceArray);
+                return ValueTask.FromResult(new MediaSourceSession(session.PlaybackUrl, owner: session));
+            });
+    }
+
+    private static IReadOnlyDictionary<string, string> CopyAndValidate(
+        IReadOnlyDictionary<string, string>? values,
+        string parameterName,
+        bool rejectNewLines)
+    {
+        if (values is null || values.Count == 0)
+            return MediaSourceSession.EmptyValues;
+
+        var copy = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in values)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Keys cannot be empty.", parameterName);
+            if (value is null)
+                throw new ArgumentException($"Value for '{key}' cannot be null.", parameterName);
+            if (rejectNewLines && (key.Contains('\r') || key.Contains('\n') || value.Contains('\r') || value.Contains('\n')))
+                throw new ArgumentException("HTTP headers cannot contain newlines.", parameterName);
+
+            copy[key] = value;
+        }
+
+        return new ReadOnlyDictionary<string, string>(copy);
+    }
+}
+
+/// <summary>Identifies the backing mechanism used by a media source.</summary>
+public enum MediaSourceKind
+{
+    File,
+    Uri,
+    Stream,
+    Manifest,
+    YouTube
+}
+
+/// <summary>Describes one seekable resource used by a stream or manifest source.</summary>
+public sealed record MediaResource
+{
+    public MediaResource(
+        string fileName,
+        string contentType,
+        long length,
+        Func<CancellationToken, ValueTask<Stream>> openAsync)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+        if (contentType.Contains('\r') || contentType.Contains('\n'))
+            throw new ArgumentException("Content type cannot contain newlines.", nameof(contentType));
+        if (fileName.Contains('/') || fileName.Contains('\\'))
+            throw new ArgumentException("Resource file names cannot contain directory separators.", nameof(fileName));
+        if (length <= 0)
+            throw new ArgumentOutOfRangeException(nameof(length), "Resource length must be greater than zero.");
+
+        FileName = fileName;
+        ContentType = contentType;
+        Length = length;
+        OpenAsync = openAsync ?? throw new ArgumentNullException(nameof(openAsync));
+    }
+
+    public string FileName { get; }
+    public string ContentType { get; }
+    public long Length { get; }
+    public Func<CancellationToken, ValueTask<Stream>> OpenAsync { get; }
+}
+
+internal sealed class MediaSourceSession : IAsyncDisposable, IDisposable
+{
+    internal static IReadOnlyDictionary<string, string> EmptyValues { get; } =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+
+    private readonly IAsyncDisposable? _asyncOwner;
+    private readonly IDisposable? _owner;
+    private int _disposed;
+
+    internal MediaSourceSession(
+        string location,
+        IReadOnlyDictionary<string, string>? headers = null,
+        IReadOnlyDictionary<string, string>? ffmpegOptions = null,
+        object? owner = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(location);
+        Location = location;
+        Headers = headers ?? EmptyValues;
+        FFmpegOptions = ffmpegOptions ?? EmptyValues;
+        _asyncOwner = owner as IAsyncDisposable;
+        _owner = owner as IDisposable;
+    }
+
+    internal string Location { get; }
+    internal IReadOnlyDictionary<string, string> Headers { get; }
+    internal IReadOnlyDictionary<string, string> FFmpegOptions { get; }
+
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        if (_asyncOwner is not null)
+            await _asyncOwner.DisposeAsync().ConfigureAwait(false);
+        else
+            _owner?.Dispose();
+    }
+}

--- a/FFmpegVideoPlayer.Core/Media/PlaybackModels.cs
+++ b/FFmpegVideoPlayer.Core/Media/PlaybackModels.cs
@@ -1,0 +1,114 @@
+namespace FFmpegVideoPlayer.Core;
+
+/// <summary>Represents the complete lifecycle of a media player.</summary>
+public enum PlaybackState
+{
+    Closed,
+    Opening,
+    Ready,
+    Playing,
+    Paused,
+    Stopped,
+    Ended,
+    Failed,
+    Disposed
+}
+
+/// <summary>Stable error categories suitable for application logic.</summary>
+public enum MediaErrorCode
+{
+    Unknown,
+    InvalidSource,
+    SourceNotFound,
+    Network,
+    Timeout,
+    Cancelled,
+    UnsupportedFormat,
+    DecoderUnavailable,
+    AudioOutputUnavailable,
+    NativeLibraryUnavailable,
+    PlaybackFailed
+}
+
+/// <summary>Describes a media failure without exposing credentials from its source URL.</summary>
+public sealed record MediaError(
+    MediaErrorCode Code,
+    string Message,
+    int? NativeErrorCode = null,
+    Exception? Exception = null);
+
+/// <summary>Result returned by media open operations.</summary>
+public sealed record MediaOpenResult
+{
+    private MediaOpenResult(bool succeeded, MediaInfo? mediaInfo, MediaError? error)
+    {
+        Succeeded = succeeded;
+        MediaInfo = mediaInfo;
+        Error = error;
+    }
+
+    public bool Succeeded { get; }
+    public MediaInfo? MediaInfo { get; }
+    public MediaError? Error { get; }
+
+    public static MediaOpenResult Success(MediaInfo mediaInfo) =>
+        new(true, mediaInfo ?? throw new ArgumentNullException(nameof(mediaInfo)), null);
+
+    public static MediaOpenResult Failure(MediaError error) =>
+        new(false, null, error ?? throw new ArgumentNullException(nameof(error)));
+}
+
+/// <summary>Information discovered when FFmpeg opens a source.</summary>
+public sealed record MediaInfo(
+    string DisplayName,
+    TimeSpan Duration,
+    bool HasVideo,
+    bool HasAudio,
+    int VideoWidth,
+    int VideoHeight);
+
+/// <summary>Controls bounded network I/O for open and playback operations.</summary>
+public sealed record MediaOpenOptions
+{
+    public static MediaOpenOptions Default { get; } = new();
+
+    public TimeSpan OpenTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ReadTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    internal void Validate()
+    {
+        if (OpenTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(OpenTimeout));
+        if (ReadTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(ReadTimeout));
+    }
+}
+
+public sealed class MediaFailedEventArgs : EventArgs
+{
+    public MediaFailedEventArgs(MediaError error, MediaSource? source = null)
+    {
+        Error = error ?? throw new ArgumentNullException(nameof(error));
+        Source = source;
+    }
+
+    public MediaError Error { get; }
+
+    /// <summary>
+    /// Gets the source that failed. This is null only for failures that happen
+    /// before a source has been assigned, such as native-library initialization.
+    /// </summary>
+    public MediaSource? Source { get; }
+}
+
+public sealed class PlaybackStateChangedEventArgs : EventArgs
+{
+    public PlaybackStateChangedEventArgs(PlaybackState previousState, PlaybackState state)
+    {
+        PreviousState = previousState;
+        State = state;
+    }
+
+    public PlaybackState PreviousState { get; }
+    public PlaybackState State { get; }
+}

--- a/FFmpegVideoPlayer.Core/Media/YouTubeMediaSourceResolver.cs
+++ b/FFmpegVideoPlayer.Core/Media/YouTubeMediaSourceResolver.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using YoutubeExplode;
+using YoutubeExplode.Videos;
+using YoutubeExplode.Videos.Streams;
+
+namespace FFmpegVideoPlayer.Core;
+
+/// <summary>
+/// Resolves a YouTube watch URL into a local DASH manifest consumed by the existing
+/// FFmpeg player. Audio and video remain separate upstream streams and are relayed
+/// in memory over loopback, so no tutorial video is stored on disk.
+/// </summary>
+public sealed class YouTubeMediaSourceResolver
+{
+    private readonly int _preferredMaximumHeight;
+    private readonly YoutubeClient _youtube;
+
+    public static YouTubeMediaSourceResolver Instance { get; } = new();
+
+    public YouTubeMediaSourceResolver(int preferredMaximumHeight = 1080)
+        : this(new YoutubeClient(), preferredMaximumHeight)
+    {
+    }
+
+    internal YouTubeMediaSourceResolver(YoutubeClient youtube, int preferredMaximumHeight = 1080)
+    {
+        _youtube = youtube ?? throw new ArgumentNullException(nameof(youtube));
+        if (preferredMaximumHeight <= 0)
+            throw new ArgumentOutOfRangeException(nameof(preferredMaximumHeight));
+        _preferredMaximumHeight = preferredMaximumHeight;
+    }
+
+    public static bool IsSupportedUrl(string value)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+            return false;
+        return uri.Host.Equals("youtu.be", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals("youtube.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.EndsWith(".youtube.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public MediaSource CreateSource(string youtubeUrl)
+    {
+        var videoId = VideoId.Parse(youtubeUrl);
+        return MediaSource.FromSessionFactory(
+            $"YouTube {videoId}",
+            MediaSourceKind.YouTube,
+            token => ResolveSessionAsync(youtubeUrl, token));
+    }
+
+    private async ValueTask<MediaSourceSession> ResolveSessionAsync(
+        string youtubeUrl,
+        CancellationToken cancellationToken = default)
+    {
+        var videoId = VideoId.Parse(youtubeUrl);
+        var videoTask = _youtube.Videos.GetAsync(videoId, cancellationToken).AsTask();
+        var streamsTask = _youtube.Videos.Streams.GetManifestAsync(videoId, cancellationToken).AsTask();
+        await Task.WhenAll(videoTask, streamsTask).ConfigureAwait(false);
+
+        var video = await videoTask.ConfigureAwait(false);
+        var streamManifest = await streamsTask.ConfigureAwait(false);
+        var duration = video.Duration;
+        if (duration is null || duration <= TimeSpan.Zero)
+            throw new InvalidOperationException($"YouTube video '{videoId}' did not report a duration.");
+
+        var videoStream = SelectVideoStream(streamManifest)
+            ?? throw new InvalidOperationException($"YouTube video '{videoId}' has no compatible video stream.");
+        var audioStream = SelectAudioStream(streamManifest)
+            ?? throw new InvalidOperationException($"YouTube video '{videoId}' has no compatible audio stream.");
+
+        var videoRangesTask = ResolveSegmentBaseRangesAsync(videoStream, cancellationToken).AsTask();
+        var audioRangesTask = ResolveSegmentBaseRangesAsync(audioStream, cancellationToken).AsTask();
+        await Task.WhenAll(videoRangesTask, audioRangesTask).ConfigureAwait(false);
+        var videoRanges = await videoRangesTask.ConfigureAwait(false);
+        var audioRanges = await audioRangesTask.ConfigureAwait(false);
+
+        const string manifestFileName = "youtube.mpd";
+        const string videoFileName = "video.mp4";
+        const string audioFileName = "audio.mp4";
+        var dashManifest = BuildDashManifest(
+            duration.Value,
+            videoFileName,
+            videoStream,
+            videoRanges,
+            audioFileName,
+            audioStream,
+            audioRanges);
+
+        var loopback = new LoopbackMediaSession(
+            manifestFileName,
+            dashManifest,
+            [
+                new MediaResource(
+                    videoFileName,
+                    "video/mp4",
+                    videoStream.Size.Bytes,
+                    token => _youtube.Videos.Streams.GetAsync(videoStream, token)),
+                new MediaResource(
+                    audioFileName,
+                    "audio/mp4",
+                    audioStream.Size.Bytes,
+                    token => _youtube.Videos.Streams.GetAsync(audioStream, token)),
+            ]);
+        return new MediaSourceSession(loopback.PlaybackUrl, owner: loopback);
+    }
+
+    internal IVideoStreamInfo? SelectVideoStream(StreamManifest manifest)
+    {
+        var compatible = manifest
+            .GetVideoOnlyStreams()
+            .Where(stream => stream.Container == Container.Mp4)
+            .Where(stream =>
+                stream.VideoCodec.StartsWith("avc1", StringComparison.OrdinalIgnoreCase)
+                || stream.VideoCodec.StartsWith("h264", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (compatible.Length == 0)
+            compatible = manifest.GetVideoOnlyStreams().Where(stream => stream.Container == Container.Mp4).ToArray();
+
+        var preferred = compatible
+            .Where(stream => stream.VideoResolution.Height <= _preferredMaximumHeight)
+            .ToArray();
+        var candidates = preferred.Length > 0 ? preferred : compatible;
+
+        return candidates
+            .OrderByDescending(stream => stream.VideoResolution.Area)
+            .ThenByDescending(stream => stream.VideoQuality.Framerate)
+            .ThenByDescending(stream => stream.Bitrate.BitsPerSecond)
+            .FirstOrDefault();
+    }
+
+    internal static IAudioStreamInfo? SelectAudioStream(StreamManifest manifest) =>
+        manifest
+            .GetAudioOnlyStreams()
+            .Where(stream => stream.Container == Container.Mp4)
+            .OrderByDescending(stream => stream.IsAudioLanguageDefault == true)
+            .ThenByDescending(stream => stream.Bitrate.BitsPerSecond)
+            .FirstOrDefault();
+
+    internal static string BuildDashManifest(
+        TimeSpan duration,
+        string videoFileName,
+        IVideoStreamInfo video,
+        SegmentBaseRanges videoRanges,
+        string audioFileName,
+        IAudioStreamInfo audio,
+        SegmentBaseRanges audioRanges)
+    {
+        var builder = new StringBuilder();
+        using var writer = XmlWriter.Create(builder, new XmlWriterSettings
+        {
+            Encoding = Encoding.UTF8,
+            Indent = true,
+            OmitXmlDeclaration = true,
+        });
+
+        const string dashNamespace = "urn:mpeg:dash:schema:mpd:2011";
+        writer.WriteStartElement("MPD", dashNamespace);
+        writer.WriteAttributeString("type", "static");
+        writer.WriteAttributeString("mediaPresentationDuration", XmlConvert.ToString(duration));
+        writer.WriteAttributeString("minBufferTime", "PT1.5S");
+        writer.WriteAttributeString("profiles", "urn:mpeg:dash:profile:isoff-on-demand:2011");
+
+        writer.WriteStartElement("Period", dashNamespace);
+        writer.WriteAttributeString("start", "PT0S");
+
+        writer.WriteStartElement("AdaptationSet", dashNamespace);
+        writer.WriteAttributeString("contentType", "video");
+        writer.WriteAttributeString("segmentAlignment", "true");
+
+        writer.WriteStartElement("Representation", dashNamespace);
+        writer.WriteAttributeString("id", "v");
+        writer.WriteAttributeString("bandwidth", video.Bitrate.BitsPerSecond.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("mimeType", "video/mp4");
+        writer.WriteAttributeString("codecs", video.VideoCodec);
+        writer.WriteAttributeString("width", video.VideoResolution.Width.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("height", video.VideoResolution.Height.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("frameRate", video.VideoQuality.Framerate.ToString(CultureInfo.InvariantCulture));
+        WriteSegmentBase(writer, dashNamespace, videoFileName, videoRanges);
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+
+        writer.WriteStartElement("AdaptationSet", dashNamespace);
+        writer.WriteAttributeString("contentType", "audio");
+        writer.WriteAttributeString("segmentAlignment", "true");
+
+        writer.WriteStartElement("Representation", dashNamespace);
+        writer.WriteAttributeString("id", "a");
+        writer.WriteAttributeString("bandwidth", audio.Bitrate.BitsPerSecond.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("mimeType", "audio/mp4");
+        writer.WriteAttributeString("codecs", audio.AudioCodec);
+        WriteSegmentBase(writer, dashNamespace, audioFileName, audioRanges);
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
+        writer.Flush();
+        return builder.ToString();
+    }
+
+    private async ValueTask<SegmentBaseRanges> ResolveSegmentBaseRangesAsync(
+        IStreamInfo streamInfo,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = await _youtube.Videos.Streams
+            .GetAsync(streamInfo, cancellationToken)
+            .ConfigureAwait(false);
+        return await FindSegmentBaseRangesAsync(stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async ValueTask<SegmentBaseRanges> FindSegmentBaseRangesAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        var header = new byte[16];
+        long position = 0;
+        for (var boxCount = 0; boxCount < 128 && position < 16 * 1024 * 1024; boxCount++)
+        {
+            stream.Position = position;
+            await stream.ReadExactlyAsync(header.AsMemory(0, 8), cancellationToken).ConfigureAwait(false);
+            var size = (long)BinaryPrimitives.ReadUInt32BigEndian(header.AsSpan(0, 4));
+            var type = Encoding.ASCII.GetString(header, 4, 4);
+            var headerSize = 8L;
+
+            if (size == 1)
+            {
+                await stream.ReadExactlyAsync(header.AsMemory(8, 8), cancellationToken).ConfigureAwait(false);
+                size = checked((long)BinaryPrimitives.ReadUInt64BigEndian(header.AsSpan(8, 8)));
+                headerSize = 16;
+            }
+            else if (size == 0)
+            {
+                size = stream.Length - position;
+            }
+
+            if (size < headerSize || position + size > stream.Length)
+                throw new InvalidDataException($"Invalid MP4 box '{type}' at offset {position}.");
+
+            if (type == "sidx")
+            {
+                if (position == 0)
+                    throw new InvalidDataException("MP4 stream has no initialization data before its sidx box.");
+
+                return new SegmentBaseRanges(position - 1, position, position + size - 1);
+            }
+
+            if (type is "moof" or "mdat")
+                break;
+
+            position += size;
+        }
+
+        throw new InvalidDataException("YouTube MP4 stream has no top-level sidx box.");
+    }
+
+    private static void WriteSegmentBase(
+        XmlWriter writer,
+        string dashNamespace,
+        string fileName,
+        SegmentBaseRanges ranges)
+    {
+        writer.WriteElementString("BaseURL", dashNamespace, fileName);
+        writer.WriteStartElement("SegmentBase", dashNamespace);
+        writer.WriteAttributeString(
+            "indexRange",
+            $"{ranges.IndexStart.ToString(CultureInfo.InvariantCulture)}-{ranges.IndexEnd.ToString(CultureInfo.InvariantCulture)}");
+        writer.WriteAttributeString("indexRangeExact", "true");
+        writer.WriteStartElement("Initialization", dashNamespace);
+        writer.WriteAttributeString(
+            "range",
+            $"0-{ranges.InitializationEnd.ToString(CultureInfo.InvariantCulture)}");
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+    }
+}
+
+internal sealed record SegmentBaseRanges(long InitializationEnd, long IndexStart, long IndexEnd);

--- a/FFmpegVideoPlayer.Core/PlayerLogger.cs
+++ b/FFmpegVideoPlayer.Core/PlayerLogger.cs
@@ -8,30 +8,28 @@ using System.Text.Json;
 namespace FFmpegVideoPlayer.Core;
 
 /// <summary>
-/// JSON logger for player operations. Logs all player commands and state changes to a JSON file.
+/// Lightweight diagnostic logger for player operations. File logging is opt-in so
+/// applications are never required to grant write access to their installation directory.
 /// </summary>
 public sealed class PlayerLogger : IDisposable
 {
     private readonly List<LogEntry> _logEntries = new();
     private readonly object _lock = new();
-    private readonly string _logFilePath;
+    private readonly string? _logFilePath;
     private bool _disposed;
     private DateTime _lastFlush = DateTime.Now;
 
     public PlayerLogger(string? logFilePath = null)
     {
-        if (string.IsNullOrEmpty(logFilePath))
+        if (!string.IsNullOrWhiteSpace(logFilePath))
         {
-            var logDir = Path.Combine(AppContext.BaseDirectory, "debug");
-            Directory.CreateDirectory(logDir);
-            _logFilePath = Path.Combine(logDir, $"player-log-{DateTime.Now:yyyyMMdd-HHmmss}.json");
-        }
-        else
-        {
-            _logFilePath = logFilePath;
+            _logFilePath = Path.GetFullPath(logFilePath);
+            var directory = Path.GetDirectoryName(_logFilePath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
         }
 
-        Log("PlayerLogger", "Initialized", new { LogFile = _logFilePath });
+        Log("PlayerLogger", "Initialized", new { FileLoggingEnabled = _logFilePath != null });
     }
 
     public void Log(string component, string operation, object? data = null)
@@ -51,12 +49,12 @@ public sealed class PlayerLogger : IDisposable
 
             _logEntries.Add(entry);
 
-            // Also write to debug output for immediate visibility
-            var dataStr = data != null ? $" | Data: {JsonSerializer.Serialize(data)}" : "";
-            Debug.WriteLine($"[{entry.TimestampLocal:HH:mm:ss.fff}] [{component}] {operation}{dataStr}");
+            // Do not emit data by default: media URLs can contain signed query strings,
+            // cookies, or other credentials. Applications can opt into a JSON log file.
+            Debug.WriteLine($"[{entry.TimestampLocal:HH:mm:ss.fff}] [{component}] {operation}");
             
             // Auto-flush every 5 seconds to ensure logs are saved even if app crashes
-            if ((DateTime.Now - _lastFlush).TotalSeconds > 5)
+            if (_logFilePath != null && (DateTime.Now - _lastFlush).TotalSeconds > 5)
             {
                 Flush();
             }
@@ -71,6 +69,9 @@ public sealed class PlayerLogger : IDisposable
             
             var clearedCount = _logEntries.Count;
             _logEntries.Clear();
+
+            if (_logFilePath == null)
+                return;
             
             // Write empty array to file to clear it
             try
@@ -97,7 +98,7 @@ public sealed class PlayerLogger : IDisposable
     {
         lock (_lock)
         {
-            if (_disposed || _logEntries.Count == 0) return;
+            if (_disposed || _logFilePath == null || _logEntries.Count == 0) return;
 
             try
             {
@@ -122,9 +123,35 @@ public sealed class PlayerLogger : IDisposable
 
     public void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
-        Flush();
+        lock (_lock)
+        {
+            if (_disposed) return;
+            FlushCore();
+            _disposed = true;
+        }
+    }
+
+    private void FlushCore()
+    {
+        if (_logFilePath == null || _logEntries.Count == 0)
+            return;
+
+        try
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+
+            var json = JsonSerializer.Serialize(_logEntries, options);
+            File.WriteAllText(_logFilePath, json, Encoding.UTF8);
+            _lastFlush = DateTime.Now;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[PlayerLogger] Failed to write log file: {ex.Message}");
+        }
     }
 
     private class LogEntry

--- a/FFmpegVideoPlayer.Rendering.OpenGL/FFmpegVideoPlayer.Rendering.OpenGL.csproj
+++ b/FFmpegVideoPlayer.Rendering.OpenGL/FFmpegVideoPlayer.Rendering.OpenGL.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -11,7 +12,6 @@
     <PackageId>FFmpegVideoPlayer.Rendering.OpenGL</PackageId>
     <AssemblyName>FFmpegVideoPlayer.Rendering.OpenGL</AssemblyName>
     <RootNamespace>FFmpegVideoPlayer.Rendering.OpenGL</RootNamespace>
-    <Version>2.1.8</Version>
     <Authors>jojomondag</Authors>
     <Company>jojomondag</Company>
     <Description>OpenGL-based hardware-accelerated rendering for FFmpegVideoPlayer. Provides OpenGL texture-based video rendering for improved performance.</Description>
@@ -31,8 +31,8 @@
     <ProjectReference Include="..\Avalonia.FFmpegVideoPlayer.csproj" />
     
     <!-- OpenTK for OpenGL support -->
-    <PackageReference Include="OpenTK" Version="4.8.2" />
-    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="OpenTK" Version="4.9.4" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
   </ItemGroup>
 
 </Project>

--- a/LICENSES/GPL-3.0.txt
+++ b/LICENSES/GPL-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/LICENSES/LGPL-2.0-or-later.txt
+++ b/LICENSES/LGPL-2.0-or-later.txt
@@ -1,0 +1,480 @@
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/LICENSES/LGPL-3.0-or-later.txt
+++ b/LICENSES/LGPL-3.0-or-later.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -3,17 +3,27 @@
 
 # FFmpegVideoPlayer.Avalonia
 
-FFmpeg-based media player control for Avalonia, with video and audio-only playback. Works on Windows, macOS, and Linux (including Apple Silicon).
+Standalone FFmpeg media player for Avalonia 12. It owns source resolution, streaming,
+playback lifecycle, cancellation and cleanup for local video/audio, HTTP media,
+seekable streams, DASH manifests and YouTube URLs.
 
 ![Preview](https://raw.githubusercontent.com/jojomondag/FFmpegVideoPlayer.Avalonia/main/images/Preview1.png)
 
 ## Install
 
 ```bash
-dotnet add package FFmpegVideoPlayer.Avalonia
+dotnet add package FFmpegVideoPlayer.Avalonia --version 3.0.0
 ```
 
-Requires **Avalonia 11.3.15+** and **.NET 8+**.
+Version 3 requires **Avalonia 12.1.0+ (below 13)** and **.NET 8+**. The single
+package contains the Avalonia control, Core and OpenTK/OpenAL audio implementation;
+applications do not reference separate player packages.
+
+The managed player API is cross-platform, but the native payload is platform-specific:
+FFmpeg 8.0.1 DLLs are bundled **only for Windows x64**. Windows x86/ARM64, macOS,
+and Linux require a compatible system FFmpeg installation or an explicitly supplied
+native-library path. OpenAL Soft audio DLLs are bundled separately for Windows x64,
+x86, and ARM64.
 
 ## Quick start
 
@@ -35,15 +45,48 @@ xmlns:ffmpeg="clr-namespace:Avalonia.FFmpegVideoPlayer;assembly=Avalonia.FFmpegV
 
 Video and audio-only files are both supported, for example `.mp4`, `.mov`, `.mp3`, `.wav`, `.flac`, `.ogg`, and `.m4a`.
 
-Audio (OpenAL) is included in the main package. On Windows, install [OpenAL Soft](https://www.openal-soft.org/) or place `OpenAL32.dll` next to your app — otherwise playback is video-only.
+`Source` also accepts direct HTTP(S) and YouTube URLs. Source changes are resolved
+asynchronously and stale opens are cancelled automatically:
+
+```xml
+<ffmpeg:VideoPlayerControl
+    Source="https://youtu.be/Ppejf4-YmSM"
+    AutoPlay="True"
+    ShowOpenButton="False" />
+```
+
+For custom headers, in-memory media or manifests, use the typed API:
+
+```csharp
+var source = MediaSource.FromUri(
+    new Uri("https://media.example/video.mp4"),
+    headers: new Dictionary<string, string> { ["Authorization"] = "Bearer …" });
+
+var result = await player.OpenAsync(
+    source,
+    new MediaOpenOptions
+    {
+        OpenTimeout = TimeSpan.FromSeconds(20),
+        ReadTimeout = TimeSpan.FromSeconds(30)
+    },
+    cancellationToken);
+```
+
+OpenAL Soft binaries for Windows x64, x86 and ARM64 are included in the package.
 
 ## FFmpeg
 
 | Platform | Default |
 |----------|---------|
 | Windows x64 | Bundled DLLs in the package |
-| macOS | System/Homebrew (`brew install ffmpeg`); can auto-install |
-| Linux | System packages (apt/dnf/pacman); can auto-install with passwordless sudo |
+| Windows x86 / ARM64 | Compatible system FFmpeg 8 native libraries or a custom path |
+| macOS (x64 / ARM64) | System/Homebrew (`brew install ffmpeg`); can auto-install |
+| Linux (x64 / ARM64) | System packages (apt/dnf/pacman); can auto-install with passwordless sudo |
+
+On every row except Windows x64, FFmpeg is a system/native prerequisite; it is not
+contained in the NuGet package. Automatic installation, where supported, installs that
+system prerequisite. The required FFmpeg 8 library ABI is `avcodec-62`, `avformat-62`,
+`avutil-60`, `swresample-6`, and `swscale-9`.
 
 Custom FFmpeg path:
 
@@ -63,9 +106,18 @@ dotnet run
 
 ## VideoPlayerControl
 
-**Properties:** `Source`, `AutoPlay`, `Volume`, `ShowControls`, `ShowOpenButton`, `VideoStretch`, `VideoBackground`, `EnableKeyboardShortcuts`, `RenderingMode` (`Cpu` / `OpenGL`), `AudioPlayerFactory`, `IconProvider`
+**Sources:** `Source` for a path/URL, or typed `Media` for reusable
+`MediaSource` recipes.
 
-**Methods:** `Open`, `OpenUri`, `Play`, `Pause`, `Stop`, `TogglePlayPause`, `Seek`, `ToggleMute`
+**Lifecycle:** `PlaybackState`, `LastError`, `MediaOpening`, `MediaOpened`,
+`MediaFailed`, `PlaybackStateChanged`, and `MediaEnded`.
+
+**Methods:** `OpenAsync`, `Open`, `OpenUri`, `CloseAsync`, `Play`, `Pause`,
+`Stop`, `TogglePlayPause`, `Seek`, and `ToggleMute`.
+
+**Presentation:** `AutoPlay`, `Volume`, `ShowControls`, `ShowOpenButton`,
+`VideoStretch`, `VideoBackground`, `EnableKeyboardShortcuts`, `RenderingMode`
+(`Cpu` / `OpenGL`), `AudioPlayerFactory`, and `IconProvider`.
 
 **Shortcuts:** Space (play/pause), arrow keys (seek/volume), M (mute)
 
@@ -75,4 +127,7 @@ Custom icons: implement `IIconProvider` and set `IconProvider`.
 
 ## License
 
-MIT
+The managed project code is licensed under MIT. The NuGet package also redistributes
+FFmpeg and OpenAL Soft native libraries under their respective GNU LGPL terms. See
+[`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md) for provenance, checksums, source
+availability, replacement rights, and the packaged license-text locations.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,102 @@
+# Third-Party Notices
+
+`FFmpegVideoPlayer.Avalonia` is MIT-licensed, but its NuGet package also
+redistributes the native libraries identified below. Those libraries remain under
+their own copyright and license terms; the project's MIT license does not replace
+or restrict those terms.
+
+## FFmpeg 8.0.1 release-branch build
+
+Copyright (c) 2000-2025 the FFmpeg developers and other contributors.
+
+The Windows x64 package payload contains five dynamically loaded FFmpeg libraries.
+Each DLL reports version `n8.0.1-23-gf9a3e1b776-20251204`, i.e. FFmpeg's 8.0
+release branch at commit
+[`f9a3e1b7763669c5a29287b1dadc2f6288677e97`](https://github.com/FFmpeg/FFmpeg/commit/f9a3e1b7763669c5a29287b1dadc2f6288677e97).
+Each DLL also reports `LGPL version 3 or later`. Its embedded configure command
+contains `--enable-version3 --enable-shared --disable-static`, disables GPL-only
+and nonfree components, and identifies the `/ffbuild` Windows x64 build environment.
+Accordingly, these particular binaries are distributed under
+**GNU LGPL version 3 or later**, not LGPL 2.1.
+FFmpeg's official source and licensing pages are
+<https://ffmpeg.org/download.html> and <https://ffmpeg.org/legal.html>; its
+canonical Git repository is <https://git.ffmpeg.org/ffmpeg.git>.
+
+The configuration and version format are consistent with BtbN's
+`win64-lgpl-shared` build family, but that is a reproducibility reference rather
+than verified archive provenance. A build-recipe snapshot immediately preceding
+the DLL build date is
+[`BtbN/FFmpeg-Builds@766a6a2c088ff771a5d383428def6f5791490e56`](https://github.com/BtbN/FFmpeg-Builds/tree/766a6a2c088ff771a5d383428def6f5791490e56).
+That recipe records enabled third-party components, source URLs, checksums, and
+build commands, but the repository cannot verify that it was the recipe actually
+used for these DLLs. The original downloaded archive name, URL, and archive checksum
+were not retained when the DLLs were imported, so this notice does not invent them:
+the embedded version/configuration and the per-file SHA-256 values below are the
+authoritative identifiers for the files actually redistributed by this package.
+
+| Packaged file | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `runtimes/win-x64/native/avcodec-62.dll` | 78,149,120 | `3EECF00886B7A22C4C2AE4999D9132C989C3170187D254F59FD2006FA79FBF35` |
+| `runtimes/win-x64/native/avformat-62.dll` | 21,750,272 | `B689A6101A1AB8286C5D9F2DBF10ABC574EA23CCB98F2B45AFBCC885EB1DF1E2` |
+| `runtimes/win-x64/native/avutil-60.dll` | 2,939,904 | `8B6729BAD95392537E0BBA73BCE61587212EFE179E0381DD2AF9574F8717CC23` |
+| `runtimes/win-x64/native/swresample-6.dll` | 723,456 | `BAC2C3EC4D27B1112B8F4DFBA924DC272FB611F424FCC80AD7EA0D88368D1C7A` |
+| `runtimes/win-x64/native/swscale-9.dll` | 1,910,272 | `D0324617295B3F055FD4C60002A60642D1625CCE91B87C4F6183F63FA7D1FC00` |
+
+License texts are packaged as [`LICENSES/LGPL-3.0-or-later.txt`](LICENSES/LGPL-3.0-or-later.txt)
+and, because LGPLv3 incorporates GPLv3, [`LICENSES/GPL-3.0.txt`](LICENSES/GPL-3.0.txt).
+FFmpeg's copyright, credits, and file-level licensing details remain in its
+corresponding source tree.
+
+## OpenAL Soft 1.23.1
+
+Copyright (c) the OpenAL Soft contributors. OpenAL Soft is distributed under the
+**GNU Library General Public License version 2 or, at your option, any later
+version** (`LGPL-2.0-or-later`). The complete version 2 text is packaged as
+[`LICENSES/LGPL-2.0-or-later.txt`](LICENSES/LGPL-2.0-or-later.txt).
+
+The DLLs are copied without modification at pack time from the signed NuGet package
+[`OpenAL.Soft` 1.23.1](https://www.nuget.org/packages/OpenAL.Soft/1.23.1). The
+upstream release source is tag `1.23.1`, commit
+[`d3875f333fb6abe2f39d82caca329414871ae53b`](https://github.com/kcat/openal-soft/tree/d3875f333fb6abe2f39d82caca329414871ae53b).
+
+Source NuGet package identifiers:
+
+- SHA-256: `7FF3BF3FB4ACEC10347BE1C0F79F630296F42BCBE76E39F09210C891C5630029`
+- NuGet SHA-512 (Base64): `0QLOJooC9vW5J+uZKk+NK8O5L2Sztk5P7PCKRc/amgLsg1ACDzhiFMPQcMasxBLDluF+IOOFjOc46RL8cuVUsg==`
+
+| Packaged file | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `runtimes/win-x64/native/OpenAL32.dll` | 1,085,440 | `51480056B5AC1618F75DEF04CB92935C3543C73F80A8E481051C8D5F588E14E7` |
+| `runtimes/win-x86/native/OpenAL32.dll` | 981,504 | `7A9E095055BA9236F4E468D05EE9AA42122C1405E088B34AB8BCC62E613E5907` |
+| `runtimes/win-arm64/native/OpenAL32.dll` | 1,062,912 | `AD4CB474034A6700D8FC1B522A43CE8ABF3A2618B1D324D6178994A626A8CE8E` |
+
+## Corresponding source and written offer
+
+Equivalent network access to the source and build material is available here:
+
+- FFmpeg exact source:
+  <https://github.com/FFmpeg/FFmpeg/archive/f9a3e1b7763669c5a29287b1dadc2f6288677e97.tar.gz>
+- FFmpeg official source repository and license information:
+  <https://git.ffmpeg.org/ffmpeg.git> and <https://ffmpeg.org/legal.html>
+- FFmpeg Windows build scripts and dependency recipes:
+  <https://github.com/BtbN/FFmpeg-Builds/archive/766a6a2c088ff771a5d383428def6f5791490e56.tar.gz>
+- OpenAL Soft exact source:
+  <https://github.com/kcat/openal-soft/archive/d3875f333fb6abe2f39d82caca329414871ae53b.tar.gz>
+
+For at least three years after the last distribution of a package version containing
+these native binaries, any recipient may request the complete corresponding source,
+including the scripts needed to control compilation and installation, by opening an
+issue at <https://github.com/jojomondag/FFmpegVideoPlayer.Avalonia/issues>. If the
+network locations above are no longer available, the project will provide that
+material on a medium customarily used for software interchange for no more than the
+reasonable cost of physically providing it. Include the package version and the
+binary SHA-256 from this notice in the request.
+
+## Replacement and debugging
+
+The package uses the native libraries through a shared-library mechanism. Recipients
+may replace the DLLs in their application's runtime output with modified,
+interface-compatible builds. The package license terms do not prohibit reverse
+engineering performed for debugging modifications to the LGPL-covered libraries.
+No warranty is provided for the third-party software; see the complete license texts
+for the controlling terms.

--- a/VideoPlayerControl.axaml.cs
+++ b/VideoPlayerControl.axaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -54,6 +56,9 @@ public partial class VideoPlayerControl : UserControl
     private IVideoRenderer? _videoRenderer;
     private string? _currentMediaPath;
     private bool _hasMediaLoaded;
+    private CancellationTokenSource? _sourceOpenCancellation;
+    private long _openGeneration;
+    private MediaSource? _requestedSource;
 
     /// <summary>
     /// Defines the Volume property.
@@ -85,23 +90,27 @@ public partial class VideoPlayerControl : UserControl
     public static readonly StyledProperty<string?> SourceProperty =
         AvaloniaProperty.Register<VideoPlayerControl, string?>(nameof(Source), null);
 
+    /// <summary>Defines the typed Media property.</summary>
+    public static readonly StyledProperty<MediaSource?> MediaProperty =
+        AvaloniaProperty.Register<VideoPlayerControl, MediaSource?>(nameof(Media), null);
+
     /// <summary>
     /// Defines the ControlPanelBackground property.
     /// </summary>
-    public static readonly StyledProperty<Media.IBrush?> ControlPanelBackgroundProperty =
-        AvaloniaProperty.Register<VideoPlayerControl, Media.IBrush?>(nameof(ControlPanelBackground), null);
+    public static readonly StyledProperty<global::Avalonia.Media.IBrush?> ControlPanelBackgroundProperty =
+        AvaloniaProperty.Register<VideoPlayerControl, global::Avalonia.Media.IBrush?>(nameof(ControlPanelBackground), null);
 
     /// <summary>
     /// Defines the VideoBackground property.
     /// </summary>
-    public static readonly StyledProperty<Media.IBrush?> VideoBackgroundProperty =
-        AvaloniaProperty.Register<VideoPlayerControl, Media.IBrush?>(nameof(VideoBackground), null);
+    public static readonly StyledProperty<global::Avalonia.Media.IBrush?> VideoBackgroundProperty =
+        AvaloniaProperty.Register<VideoPlayerControl, global::Avalonia.Media.IBrush?>(nameof(VideoBackground), null);
 
     /// <summary>
     /// Defines the VideoStretch property.
     /// </summary>
-    public static readonly StyledProperty<Media.Stretch> VideoStretchProperty =
-        AvaloniaProperty.Register<VideoPlayerControl, Media.Stretch>(nameof(VideoStretch), Media.Stretch.Uniform);
+    public static readonly StyledProperty<global::Avalonia.Media.Stretch> VideoStretchProperty =
+        AvaloniaProperty.Register<VideoPlayerControl, global::Avalonia.Media.Stretch>(nameof(VideoStretch), global::Avalonia.Media.Stretch.Uniform);
 
     /// <summary>
     /// Defines the EnableKeyboardShortcuts property.
@@ -174,10 +183,20 @@ public partial class VideoPlayerControl : UserControl
     }
 
     /// <summary>
+    /// Gets or sets a reusable typed media source. This takes precedence over
+    /// <see cref="Source"/> and supports custom headers, streams and manifests.
+    /// </summary>
+    public MediaSource? Media
+    {
+        get => GetValue(MediaProperty);
+        set => SetValue(MediaProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the background brush for the control panel.
     /// Default is White. Set to any brush to customize the appearance.
     /// </summary>
-    public Media.IBrush? ControlPanelBackground
+    public global::Avalonia.Media.IBrush? ControlPanelBackground
     {
         get => GetValue(ControlPanelBackgroundProperty);
         set => SetValue(ControlPanelBackgroundProperty, value);
@@ -189,7 +208,7 @@ public partial class VideoPlayerControl : UserControl
     /// When null or Transparent, the background will be transparent, allowing the parent control's background to show through.
     /// This is especially useful when playing videos with transparency or when no video is loaded.
     /// </summary>
-    public Media.IBrush? VideoBackground
+    public global::Avalonia.Media.IBrush? VideoBackground
     {
         get => GetValue(VideoBackgroundProperty);
         set => SetValue(VideoBackgroundProperty, value);
@@ -199,7 +218,7 @@ public partial class VideoPlayerControl : UserControl
     /// Gets or sets the stretch mode for the video.
     /// Default is Uniform. Options: None, Fill, Uniform, UniformToFill.
     /// </summary>
-    public Media.Stretch VideoStretch
+    public global::Avalonia.Media.Stretch VideoStretch
     {
         get => GetValue(VideoStretchProperty);
         set => SetValue(VideoStretchProperty, value);
@@ -290,12 +309,12 @@ public partial class VideoPlayerControl : UserControl
         AvaloniaProperty.Register<VideoPlayerControl, CornerRadius>(nameof(ButtonCornerRadius), new CornerRadius(3));
 
     /// <summary>Defines the ControlForeground property.</summary>
-    public static readonly StyledProperty<Media.IBrush?> ControlForegroundProperty =
-        AvaloniaProperty.Register<VideoPlayerControl, Media.IBrush?>(nameof(ControlForeground), null);
+    public static readonly StyledProperty<global::Avalonia.Media.IBrush?> ControlForegroundProperty =
+        AvaloniaProperty.Register<VideoPlayerControl, global::Avalonia.Media.IBrush?>(nameof(ControlForeground), null);
 
     /// <summary>Defines the ButtonBackground property.</summary>
-    public static readonly StyledProperty<Media.IBrush?> ButtonBackgroundProperty =
-        AvaloniaProperty.Register<VideoPlayerControl, Media.IBrush?>(nameof(ButtonBackground), null);
+    public static readonly StyledProperty<global::Avalonia.Media.IBrush?> ButtonBackgroundProperty =
+        AvaloniaProperty.Register<VideoPlayerControl, global::Avalonia.Media.IBrush?>(nameof(ButtonBackground), null);
 
     /// <summary>
     /// Gets or sets the size of playback control icons. Default is 14.
@@ -346,7 +365,7 @@ public partial class VideoPlayerControl : UserControl
     /// Gets or sets the foreground brush for control text and icons.
     /// If null, defaults to #333333.
     /// </summary>
-    public Media.IBrush? ControlForeground
+    public global::Avalonia.Media.IBrush? ControlForeground
     {
         get => GetValue(ControlForegroundProperty);
         set => SetValue(ControlForegroundProperty, value);
@@ -356,7 +375,7 @@ public partial class VideoPlayerControl : UserControl
     /// Gets or sets the background brush for playback buttons.
     /// If null, defaults to #e8e8e8.
     /// </summary>
-    public Media.IBrush? ButtonBackground
+    public global::Avalonia.Media.IBrush? ButtonBackground
     {
         get => GetValue(ButtonBackgroundProperty);
         set => SetValue(ButtonBackgroundProperty, value);
@@ -371,6 +390,12 @@ public partial class VideoPlayerControl : UserControl
     /// Gets whether the control currently has a media resource loaded.
     /// </summary>
     public bool HasMediaLoaded => _hasMediaLoaded;
+
+    /// <summary>Gets the current standalone player lifecycle state.</summary>
+    public PlaybackState PlaybackState => _mediaPlayer?.State ?? PlaybackState.Closed;
+
+    /// <summary>Gets the latest structured media error.</summary>
+    public MediaError? LastError => _mediaPlayer?.LastError;
 
     /// <summary>
     /// Gets whether a video is currently playing.
@@ -429,6 +454,15 @@ public partial class VideoPlayerControl : UserControl
     /// Occurs when media is successfully opened.
     /// </summary>
     public event EventHandler<MediaOpenedEventArgs>? MediaOpened;
+
+    /// <summary>Occurs immediately before source resolution starts.</summary>
+    public event EventHandler<MediaOpeningEventArgs>? MediaOpening;
+
+    /// <summary>Occurs when source resolution, opening, or playback fails.</summary>
+    public event EventHandler<MediaFailedEventArgs>? MediaFailed;
+
+    /// <summary>Occurs whenever the standalone player lifecycle state changes.</summary>
+    public event EventHandler<PlaybackStateChangedEventArgs>? PlaybackStateChanged;
 
     /// <summary>
     /// Occurs when playback is paused.
@@ -562,14 +596,17 @@ public partial class VideoPlayerControl : UserControl
         if (e.Property == SourceProperty)
         {
             var newSource = e.NewValue as string;
-            if (!string.IsNullOrEmpty(newSource) && _isInitialized)
-            {
-                Open(newSource);
-                if (AutoPlay)
-                {
-                    Play();
-                }
-            }
+            if (Media is null && !string.IsNullOrWhiteSpace(newSource) && _isInitialized)
+                _ = OpenFromPropertyAsync(MediaSource.FromLocation(newSource));
+            else if (Media is null && string.IsNullOrWhiteSpace(newSource))
+                _ = CloseAsync();
+        }
+        else if (e.Property == MediaProperty)
+        {
+            if (e.NewValue is MediaSource mediaSource && _isInitialized)
+                _ = OpenFromPropertyAsync(mediaSource);
+            else if (e.NewValue is null && string.IsNullOrWhiteSpace(Source))
+                _ = CloseAsync();
         }
         else if (e.Property == ShowOpenButtonProperty)
         {
@@ -580,7 +617,7 @@ public partial class VideoPlayerControl : UserControl
         }
         else if (e.Property == ControlPanelBackgroundProperty)
         {
-            if (_controlPanelBorder != null && e.NewValue is Media.IBrush brush)
+            if (_controlPanelBorder != null && e.NewValue is global::Avalonia.Media.IBrush brush)
             {
                 _controlPanelBorder.Background = brush;
             }
@@ -589,13 +626,13 @@ public partial class VideoPlayerControl : UserControl
         {
             if (_videoBorder != null)
             {
-                _videoBorder.Background = e.NewValue as Media.IBrush; // Can be null for transparency
+                _videoBorder.Background = e.NewValue as global::Avalonia.Media.IBrush; // Can be null for transparency
             }
         }
         else if (e.Property == VideoStretchProperty)
         {
             // Apply to renderer
-            if (e.NewValue is Media.Stretch rendererStretch)
+            if (e.NewValue is global::Avalonia.Media.Stretch rendererStretch)
             {
                 if (_videoRenderer is CpuVideoRenderer cpuRenderer)
                 {
@@ -629,15 +666,15 @@ public partial class VideoPlayerControl : UserControl
         }
         else if (e.Property == ControlForegroundProperty)
         {
-            ApplyControlForeground(e.NewValue as Media.IBrush);
+            ApplyControlForeground(e.NewValue as global::Avalonia.Media.IBrush);
         }
         else if (e.Property == ButtonBackgroundProperty)
         {
-            ApplyButtonBackground(e.NewValue as Media.IBrush);
+            ApplyButtonBackground(e.NewValue as global::Avalonia.Media.IBrush);
         }
     }
 
-    private void ApplyControlForeground(Media.IBrush? brush)
+    private void ApplyControlForeground(global::Avalonia.Media.IBrush? brush)
     {
         if (brush == null) return;
         // Apply to all icon Path elements
@@ -656,7 +693,7 @@ public partial class VideoPlayerControl : UserControl
         if (_totalTimeText != null) _totalTimeText.Foreground = brush;
     }
 
-    private void ApplyButtonBackground(Media.IBrush? brush)
+    private void ApplyButtonBackground(global::Avalonia.Media.IBrush? brush)
     {
         if (brush == null) return;
         var buttons = new[] {
@@ -710,6 +747,8 @@ public partial class VideoPlayerControl : UserControl
             _mediaPlayer.Stopped += OnStopped;
             _mediaPlayer.EndReached += OnEndReached;
             _mediaPlayer.FrameReady += OnFrameReady;
+            _mediaPlayer.MediaFailed += OnCoreMediaFailed;
+            _mediaPlayer.StateChanged += OnCoreStateChanged;
 
             _isInitialized = true;
             
@@ -749,14 +788,19 @@ public partial class VideoPlayerControl : UserControl
             }
             
             // Load source if set (Open() handles AutoPlay internally)
-            if (!string.IsNullOrEmpty(Source))
-            {
-                Open(Source);
-            }
+            var initialMedia = Media ?? (!string.IsNullOrWhiteSpace(Source)
+                ? MediaSource.FromLocation(Source)
+                : null);
+            if (initialMedia is not null)
+                _ = OpenFromPropertyAsync(initialMedia);
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"[VideoPlayerControl] Failed to initialize FFmpeg: {ex.Message}");
+            MediaFailed?.Invoke(this, new MediaFailedEventArgs(new MediaError(
+                MediaErrorCode.NativeLibraryUnavailable,
+                "FFmpeg or its audio output could not be initialized.",
+                Exception: ex)));
         }
     }
 
@@ -854,43 +898,123 @@ public partial class VideoPlayerControl : UserControl
         }
     }
 
-    /// <summary>
-    /// Opens and optionally plays a media file.
-    /// </summary>
-    /// <param name="path">The path to the media file.</param>
-    public void Open(string path)
+    /// <summary>Opens a local path, direct URI, or supported provider URL.</summary>
+    /// <remarks>
+    /// This compatibility method is synchronous. Bind <see cref="Source"/> or use
+    /// <see cref="OpenAsync(MediaSource, MediaOpenOptions?, CancellationToken)"/>
+    /// to keep the UI responsive for network sources.
+    /// </remarks>
+    public void Open(string path) => Open(MediaSource.FromLocation(path));
+
+    /// <summary>Synchronously opens a typed source.</summary>
+    public MediaOpenResult Open(MediaSource source, MediaOpenOptions? options = null)
     {
-        Debug.WriteLine($"[VideoPlayerControl] Open called with path: {path}");
-        
-        if (_mediaPlayer == null)
-        {
-            Debug.WriteLine("[VideoPlayerControl] FFmpeg not initialized - _mediaPlayer is null");
-            return;
-        }
+        ArgumentNullException.ThrowIfNull(source);
+        EnsurePlayerInitialized();
+        if (_mediaPlayer is null)
+            return CreateInitializationFailure();
+
+        CancelControlOpen();
+        Volatile.Write(ref _requestedSource, source);
+        _hasMediaLoaded = false;
+        MediaOpening?.Invoke(this, new MediaOpeningEventArgs(source));
+        var result = _mediaPlayer.Open(source, options);
+        if (result.Succeeded && result.MediaInfo is not null)
+            CompleteMediaOpen(source, result.MediaInfo);
+        return result;
+    }
+
+    /// <summary>Asynchronously resolves, opens and optionally plays a typed source.</summary>
+    public async Task<MediaOpenResult> OpenAsync(
+        MediaSource source,
+        MediaOpenOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        EnsurePlayerInitialized();
+        if (_mediaPlayer is null)
+            return CreateInitializationFailure();
+
+        var generation = Interlocked.Increment(ref _openGeneration);
+        Volatile.Write(ref _requestedSource, source);
+        var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var previousCancellation = Interlocked.Exchange(ref _sourceOpenCancellation, operationCancellation);
+        TryCancel(previousCancellation);
 
         _hasMediaLoaded = false;
-        Debug.WriteLine("[VideoPlayerControl] Calling _mediaPlayer.Open...");
-
-        var opened = _mediaPlayer.Open(path);
-        Debug.WriteLine($"[VideoPlayerControl] _mediaPlayer.Open returned: {opened}");
-        
-        if (!opened)
+        MediaOpening?.Invoke(this, new MediaOpeningEventArgs(source));
+        try
         {
-            Debug.WriteLine($"[VideoPlayerControl] Failed to open media: {path}");
-            return;
+            var result = await _mediaPlayer
+                .OpenAsync(source, options, operationCancellation.Token)
+                .ConfigureAwait(false);
+
+            if (generation == Volatile.Read(ref _openGeneration)
+                && result.Succeeded
+                && result.MediaInfo is not null)
+            {
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (generation == Volatile.Read(ref _openGeneration) &&
+                        ReferenceEquals(source, Volatile.Read(ref _requestedSource)))
+                    {
+                        CompleteMediaOpen(source, result.MediaInfo);
+                    }
+                });
+            }
+
+            return result;
         }
+        finally
+        {
+            Interlocked.CompareExchange(ref _sourceOpenCancellation, null, operationCancellation);
+            operationCancellation.Dispose();
+        }
+    }
 
-        _currentMediaPath = path;
+    /// <summary>Asynchronously opens a local path, URI, or supported provider URL.</summary>
+    public Task<MediaOpenResult> OpenAsync(
+        string source,
+        MediaOpenOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        OpenAsync(MediaSource.FromLocation(source), options, cancellationToken);
+
+    private async Task OpenFromPropertyAsync(MediaSource source)
+    {
+        try
+        {
+            await OpenAsync(source).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Source replacement and visual-tree detach are expected cancellation paths.
+        }
+        catch (Exception ex)
+        {
+            var error = new MediaError(
+                MediaErrorCode.PlaybackFailed,
+                $"Could not open '{source.DisplayName}'.",
+                Exception: ex);
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (ReferenceEquals(source, Volatile.Read(ref _requestedSource)))
+                    MediaFailed?.Invoke(this, new MediaFailedEventArgs(error, source));
+            });
+        }
+    }
+
+    private void CompleteMediaOpen(MediaSource source, MediaInfo mediaInfo)
+    {
+        if (_mediaPlayer is null)
+            return;
+
+        _currentMediaPath = source.DisplayName;
         _hasMediaLoaded = true;
-        Debug.WriteLine($"[VideoPlayerControl] Media loaded successfully, raising MediaOpened event");
-        MediaOpened?.Invoke(this, new MediaOpenedEventArgs(path));
+        MediaOpened?.Invoke(this, new MediaOpenedEventArgs(source, mediaInfo));
 
-        if (_mediaPlayer.HasVideo)
+        if (mediaInfo.HasVideo)
         {
             SetupVideoRenderer();
-
-            // Decode and display first frame as thumbnail/preview.
-            // This ensures the video has correct dimensions before playback starts.
             _mediaPlayer.DecodeFirstFrame();
         }
         else
@@ -899,9 +1023,22 @@ public partial class VideoPlayerControl : UserControl
         }
 
         if (AutoPlay)
-        {
             _mediaPlayer.Play();
-        }
+    }
+
+    private void EnsurePlayerInitialized()
+    {
+        if (!_isInitialized)
+            InitializePlayer();
+    }
+
+    private MediaOpenResult CreateInitializationFailure()
+    {
+        var error = new MediaError(
+            MediaErrorCode.NativeLibraryUnavailable,
+            "The FFmpeg media player is not initialized.");
+        MediaFailed?.Invoke(this, new MediaFailedEventArgs(error));
+        return MediaOpenResult.Failure(error);
     }
 
     /// <summary>
@@ -910,14 +1047,8 @@ public partial class VideoPlayerControl : UserControl
     /// <param name="uri">The URI of the media.</param>
     public void OpenUri(Uri uri)
     {
-        if (uri.IsFile)
-        {
-            Open(uri.LocalPath);
-        }
-        else
-        {
-            Open(uri.ToString());
-        }
+        ArgumentNullException.ThrowIfNull(uri);
+        Open(uri.IsFile ? MediaSource.FromPath(uri.LocalPath) : MediaSource.FromUri(uri));
     }
 
     /// <summary>
@@ -941,11 +1072,61 @@ public partial class VideoPlayerControl : UserControl
     /// </summary>
     public void Stop()
     {
+        CancelControlOpen();
         _mediaPlayer?.Stop();
         if (_seekBar != null) _seekBar.Value = 0;
         if (_currentTimeText != null) _currentTimeText.Text = "00:00";
         // Clear the renderer to show background when stopped
         _videoRenderer?.Clear();
+    }
+
+    /// <summary>Cancels pending resolution and releases the current media session.</summary>
+    public async Task CloseAsync(CancellationToken cancellationToken = default)
+    {
+        CancelControlOpen();
+        var player = _mediaPlayer;
+        if (player is null)
+            return;
+
+        try
+        {
+            await player.CloseAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _currentMediaPath = null;
+            _hasMediaLoaded = false;
+            if (_seekBar != null) _seekBar.Value = 0;
+            if (_currentTimeText != null) _currentTimeText.Text = "00:00";
+            if (_totalTimeText != null) _totalTimeText.Text = "00:00";
+            _videoRenderer?.Clear();
+        });
+    }
+
+    private void CancelControlOpen()
+    {
+        Interlocked.Increment(ref _openGeneration);
+        Volatile.Write(ref _requestedSource, null);
+        var cancellation = Interlocked.Exchange(ref _sourceOpenCancellation, null);
+        TryCancel(cancellation);
+        _mediaPlayer?.CancelPendingOpen();
+    }
+
+    private static void TryCancel(CancellationTokenSource? cancellation)
+    {
+        try
+        {
+            cancellation?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The owning open completed between the atomic exchange and cancellation.
+        }
     }
 
     /// <summary>
@@ -1005,6 +1186,19 @@ public partial class VideoPlayerControl : UserControl
         UpdatePlayPauseButton(true);
         PlaybackStarted?.Invoke(this, EventArgs.Empty);
     }
+
+    private void OnCoreMediaFailed(object? sender, MediaFailedEventArgs e)
+    {
+        var requestedSource = Volatile.Read(ref _requestedSource);
+        if (e.Source is not null && !ReferenceEquals(e.Source, requestedSource))
+            return;
+
+        _hasMediaLoaded = false;
+        MediaFailed?.Invoke(this, e);
+    }
+
+    private void OnCoreStateChanged(object? sender, PlaybackStateChangedEventArgs e) =>
+        PlaybackStateChanged?.Invoke(this, e);
 
     private void ShowAudioOnlyPlaceholder()
     {
@@ -1264,17 +1458,23 @@ public partial class VideoPlayerControl : UserControl
 
     private void Cleanup()
     {
-        if (_mediaPlayer != null)
+        CancelControlOpen();
+        var mediaPlayer = Interlocked.Exchange(ref _mediaPlayer, null);
+        if (mediaPlayer != null)
         {
-            _mediaPlayer.PositionChanged -= OnPositionChanged;
-            _mediaPlayer.LengthChanged -= OnLengthChanged;
-            _mediaPlayer.Playing -= OnPlaying;
-            _mediaPlayer.Paused -= OnPaused;
-            _mediaPlayer.Stopped -= OnStopped;
-            _mediaPlayer.EndReached -= OnEndReached;
-            _mediaPlayer.FrameReady -= OnFrameReady;
-            _mediaPlayer.Dispose();
-            _mediaPlayer = null;
+            mediaPlayer.PositionChanged -= OnPositionChanged;
+            mediaPlayer.LengthChanged -= OnLengthChanged;
+            mediaPlayer.Playing -= OnPlaying;
+            mediaPlayer.Paused -= OnPaused;
+            mediaPlayer.Stopped -= OnStopped;
+            mediaPlayer.EndReached -= OnEndReached;
+            mediaPlayer.FrameReady -= OnFrameReady;
+            mediaPlayer.MediaFailed -= OnCoreMediaFailed;
+            mediaPlayer.StateChanged -= OnCoreStateChanged;
+
+            // Source providers are extensible and may take time to observe
+            // cancellation. Never block Avalonia's visual-tree detach path.
+            _ = DisposeDetachedPlayerAsync(mediaPlayer);
         }
         
         if (_videoRenderer != null)
@@ -1287,6 +1487,19 @@ public partial class VideoPlayerControl : UserControl
         _currentMediaPath = null;
         _hasMediaLoaded = false;
     }
+
+    private static Task DisposeDetachedPlayerAsync(FFmpegMediaPlayer mediaPlayer) =>
+        Task.Run(async () =>
+        {
+            try
+            {
+                await mediaPlayer.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[VideoPlayerControl] Background cleanup failed: {ex.Message}");
+            }
+        });
 }
 
 /// <summary>
@@ -1299,10 +1512,32 @@ public sealed class MediaOpenedEventArgs : EventArgs
         Path = path;
     }
 
+    public MediaOpenedEventArgs(MediaSource source, MediaInfo mediaInfo)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        MediaInfo = mediaInfo ?? throw new ArgumentNullException(nameof(mediaInfo));
+        Path = source.DisplayName;
+    }
+
     /// <summary>
     /// Gets the full path of the media that was opened.
     /// </summary>
     public string Path { get; }
+
+    /// <summary>Gets the typed source when opened through the standalone API.</summary>
+    public MediaSource? Source { get; }
+
+    /// <summary>Gets discovered stream information.</summary>
+    public MediaInfo? MediaInfo { get; }
+}
+
+/// <summary>Provides data for the MediaOpening event.</summary>
+public sealed class MediaOpeningEventArgs : EventArgs
+{
+    public MediaOpeningEventArgs(MediaSource source) =>
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+
+    public MediaSource Source { get; }
 }
 
 /// <summary>

--- a/examples/FFmpegVideoPlayerExample/FFmpegVideoPlayerExample.csproj
+++ b/examples/FFmpegVideoPlayerExample/FFmpegVideoPlayerExample.csproj
@@ -19,9 +19,13 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
   </ItemGroup>
 
-  <!-- Reference the main library project for development/testing -->
+  <!-- Reference the public control plus its implementation projects explicitly.
+       The main project keeps them private so NuGet exposes one package, while the
+       example uses their namespaces directly during source builds. -->
   <ItemGroup>
     <ProjectReference Include="../../Avalonia.FFmpegVideoPlayer.csproj" />
+    <ProjectReference Include="../../FFmpegVideoPlayer.Core/FFmpegVideoPlayer.Core.csproj" />
+    <ProjectReference Include="../../FFmpegVideoPlayer.Audio.OpenTK/FFmpegVideoPlayer.Audio.OpenTK.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/FFmpegVideoPlayerExample/FFmpegVideoPlayerExample.csproj
+++ b/examples/FFmpegVideoPlayerExample/FFmpegVideoPlayerExample.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -9,15 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Serilog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
-    <!-- Optional: Audio support via OpenTK -->
-    <ProjectReference Include="../../FFmpegVideoPlayer.Audio.OpenTK/FFmpegVideoPlayer.Audio.OpenTK.csproj" />
   </ItemGroup>
 
   <!-- Reference the main library project for development/testing -->
@@ -25,38 +24,4 @@
     <ProjectReference Include="../../Avalonia.FFmpegVideoPlayer.csproj" />
   </ItemGroup>
 
-  <!-- Copy FFmpeg native libraries from the main project's runtimes folder -->
-  <Target Name="CopyFFmpegNativeLibraries" AfterTargets="Build">
-    <PropertyGroup>
-      <FFmpegRuntimesSource>$(MSBuildThisFileDirectory)..\..\FFmpegVideoPlayer.Core\runtimes\</FFmpegRuntimesSource>
-    </PropertyGroup>
-    <ItemGroup>
-      <FFmpegNativeFiles Include="$(FFmpegRuntimesSource)**\*.*" Exclude="$(FFmpegRuntimesSource)README.md" />
-    </ItemGroup>
-    <Copy SourceFiles="@(FFmpegNativeFiles)"
-          DestinationFiles="@(FFmpegNativeFiles->'$(OutDir)runtimes\%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(FFmpegNativeFiles)' != ''" />
-    <Message Text="Copied FFmpeg native libraries to $(OutDir)runtimes\" Importance="high" />
-  </Target>
-  
-  <!-- Copy OpenAL native libraries for audio support -->
-  <ItemGroup>
-    <!-- Include OpenAL32.dll as content that copies to output -->
-    <ContentWithTargetPath Include="$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x64\native\OpenAL32.dll"
-                           Condition="'$(NuGetPackageRoot)' != '' AND Exists('$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x64\native\OpenAL32.dll')">
-      <TargetPath>OpenAL32.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x64\native\OpenAL32.dll"
-                           Condition="'$(NuGetPackageRoot)' != '' AND Exists('$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x64\native\OpenAL32.dll')">
-      <TargetPath>runtimes\win-x64\native\OpenAL32.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x86\native\OpenAL32.dll"
-                           Condition="'$(NuGetPackageRoot)' != '' AND Exists('$(NuGetPackageRoot)openal.soft\1.19.1\runtimes\win-x86\native\OpenAL32.dll')">
-      <TargetPath>runtimes\win-x86\native\OpenAL32.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-  </ItemGroup>
 </Project>

--- a/tests/FFmpegVideoPlayer.Tests/FFmpegVideoPlayer.Tests.csproj
+++ b/tests/FFmpegVideoPlayer.Tests/FFmpegVideoPlayer.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\FFmpegVideoPlayer.Core\FFmpegVideoPlayer.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/FFmpegVideoPlayer.Tests/LoopbackMediaSessionTests.cs
+++ b/tests/FFmpegVideoPlayer.Tests/LoopbackMediaSessionTests.cs
@@ -1,0 +1,200 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using FFmpegVideoPlayer.Core;
+
+namespace FFmpegVideoPlayer.Tests;
+
+public sealed class LoopbackMediaSessionTests
+{
+    [Fact]
+    public async Task Serves_manifest_and_seekable_media_ranges_without_disk_files()
+    {
+        var media = Enumerable.Range(0, 32).Select(value => (byte)value).ToArray();
+        const string manifest = "<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\" />";
+        await using var session = new LoopbackMediaSession(
+            "media.mpd",
+            manifest,
+            [CreateMemoryResource("video.mp4", "video/mp4", media)]);
+        using var client = new HttpClient();
+
+        Assert.Equal(manifest, await client.GetStringAsync(session.PlaybackUrl));
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            new Uri(new Uri(session.PlaybackUrl), "video.mp4"));
+        request.Headers.Range = new RangeHeaderValue(5, 11);
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+        Assert.Equal(new byte[] { 5, 6, 7, 8, 9, 10, 11 }, await response.Content.ReadAsByteArrayAsync());
+        Assert.Equal(32, response.Content.Headers.ContentRange?.Length);
+        Assert.Equal(5, response.Content.Headers.ContentRange?.From);
+        Assert.Equal(11, response.Content.Headers.ContentRange?.To);
+    }
+
+    [Fact]
+    public async Task Supports_suffix_ranges_used_by_media_probe_clients()
+    {
+        var media = Encoding.ASCII.GetBytes("0123456789");
+        await using var session = new LoopbackMediaSession(
+            "media.mpd",
+            "<MPD />",
+            [CreateMemoryResource("audio.m4a", "audio/mp4", media)]);
+        using var client = new HttpClient();
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            new Uri(new Uri(session.PlaybackUrl), "audio.m4a"));
+        request.Headers.Range = new RangeHeaderValue(null, 4);
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+        Assert.Equal("6789", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Keeps_streaming_while_each_upstream_read_makes_progress()
+    {
+        var media = Enumerable.Range(0, 16).Select(value => (byte)value).ToArray();
+        var idleTimeout = TimeSpan.FromMilliseconds(250);
+        await using var session = new LoopbackMediaSession(
+            "video.mp4",
+            [new MediaResource(
+                "video.mp4",
+                "video/mp4",
+                media.LongLength,
+                _ => ValueTask.FromResult<Stream>(
+                    new DelayedSeekableStream(media, TimeSpan.FromMilliseconds(35))))],
+            readIdleTimeout: idleTimeout);
+        using var client = new HttpClient();
+        var stopwatch = Stopwatch.StartNew();
+
+        var received = await client.GetByteArrayAsync(session.PlaybackUrl);
+
+        Assert.Equal(media, received);
+        Assert.True(stopwatch.Elapsed > idleTimeout, $"Elapsed {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
+    public async Task Bounds_non_cooperative_upstream_open_and_disposes_a_late_stream()
+    {
+        var releaseOpen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateStreamDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var session = new LoopbackMediaSession(
+            "video.mp4",
+            [new MediaResource(
+                "video.mp4",
+                "video/mp4",
+                1,
+                async _ =>
+                {
+                    await releaseOpen.Task;
+                    return new TrackingMemoryStream([1], () => lateStreamDisposed.TrySetResult());
+                })],
+            upstreamOpenTimeout: TimeSpan.FromMilliseconds(100));
+        using var client = new HttpClient();
+
+        Exception? exception;
+        try
+        {
+            exception = await Record.ExceptionAsync(() => client.GetAsync(session.PlaybackUrl));
+        }
+        finally
+        {
+            releaseOpen.TrySetResult();
+        }
+
+        Assert.NotNull(exception);
+        await lateStreamDisposed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task Closes_connections_that_do_not_finish_request_headers()
+    {
+        await using var session = new LoopbackMediaSession(
+            "video.mp4",
+            [CreateMemoryResource("video.mp4", "video/mp4", [1])],
+            headerTimeout: TimeSpan.FromMilliseconds(100));
+        var uri = new Uri(session.PlaybackUrl);
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, uri.Port);
+        await using var network = client.GetStream();
+        await network.WriteAsync(Encoding.ASCII.GetBytes(
+            $"GET {uri.PathAndQuery} HTTP/1.1\r\nHost: 127.0.0.1\r\n"));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var bytesRead = await network.ReadAsync(new byte[1], timeout.Token);
+
+        Assert.Equal(0, bytesRead);
+    }
+
+    private static MediaResource CreateMemoryResource(
+        string fileName,
+        string contentType,
+        byte[] content) =>
+        new(
+            fileName,
+            contentType,
+            content.LongLength,
+            _ => ValueTask.FromResult<Stream>(new MemoryStream(content, writable: false)));
+
+    private sealed class DelayedSeekableStream(byte[] content, TimeSpan delayPerRead) : Stream
+    {
+        private int _position;
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => content.LongLength;
+        public override long Position
+        {
+            get => _position;
+            set => _position = checked((int)value);
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(delayPerRead, cancellationToken);
+            if (_position >= content.Length)
+                return 0;
+            var count = Math.Min(1, Math.Min(buffer.Length, content.Length - _position));
+            content.AsMemory(_position, count).CopyTo(buffer);
+            _position += count;
+            return count;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            Position = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => Position + offset,
+                SeekOrigin.End => Length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin))
+            };
+            return Position;
+        }
+
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class TrackingMemoryStream(byte[] content, Action onDispose)
+        : MemoryStream(content, writable: false)
+    {
+        private int _disposed;
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
+                onDispose();
+        }
+    }
+}

--- a/tests/FFmpegVideoPlayer.Tests/MediaSourceTests.cs
+++ b/tests/FFmpegVideoPlayer.Tests/MediaSourceTests.cs
@@ -1,0 +1,52 @@
+using FFmpegVideoPlayer.Core;
+
+namespace FFmpegVideoPlayer.Tests;
+
+public sealed class MediaSourceTests
+{
+    [Theory]
+    [InlineData("https://www.youtube.com/watch?v=Ppejf4-YmSM")]
+    [InlineData("https://youtu.be/Ppejf4-YmSM")]
+    public void FromLocation_detects_supported_youtube_urls(string url)
+    {
+        var source = MediaSource.FromLocation(url);
+
+        Assert.Equal(MediaSourceKind.YouTube, source.Kind);
+    }
+
+    [Fact]
+    public void FromLocation_uses_local_path_for_file_uris()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "player file.mp4");
+        var source = MediaSource.FromLocation(new Uri(path).AbsoluteUri);
+
+        Assert.Equal(MediaSourceKind.File, source.Kind);
+        Assert.Equal("player file.mp4", source.DisplayName);
+    }
+
+    [Fact]
+    public async Task Missing_local_file_returns_a_structured_source_not_found_error()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.mp4");
+        using var player = new FFmpegMediaPlayer();
+
+        var result = await player.OpenAsync(MediaSource.FromPath(path));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(MediaErrorCode.SourceNotFound, result.Error?.Code);
+    }
+
+    [Fact]
+    public void Rejects_newlines_in_http_headers_and_resource_content_types()
+    {
+        Assert.Throws<ArgumentException>(() => MediaSource.FromUri(
+            new Uri("https://example.test/video.mp4"),
+            new Dictionary<string, string> { ["Authorization"] = "secret\r\nInjected: true" }));
+
+        Assert.Throws<ArgumentException>(() => new MediaResource(
+            "video.mp4",
+            "video/mp4\r\nInjected: true",
+            1,
+            _ => ValueTask.FromResult<Stream>(new MemoryStream([0]))));
+    }
+}

--- a/tests/FFmpegVideoPlayer.Tests/PlayerLifecycleTests.cs
+++ b/tests/FFmpegVideoPlayer.Tests/PlayerLifecycleTests.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using FFmpegVideoPlayer.Core;
+
+namespace FFmpegVideoPlayer.Tests;
+
+public sealed class PlayerLifecycleTests
+{
+    [Fact]
+    public async Task Pre_cancelled_open_does_not_change_the_existing_state_or_invoke_the_factory()
+    {
+        var factoryCalled = false;
+        var source = MediaSource.FromSessionFactory(
+            "cancelled.mp4",
+            MediaSourceKind.Stream,
+            _ =>
+            {
+                factoryCalled = true;
+                return ValueTask.FromResult(new MediaSourceSession("unused"));
+            });
+        await using var player = new FFmpegMediaPlayer();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            player.OpenAsync(source, cancellationToken: cancellation.Token));
+
+        Assert.False(factoryCalled);
+        Assert.Equal(PlaybackState.Closed, player.State);
+    }
+
+    [Fact]
+    public async Task Cancellation_during_source_resolution_is_not_reported_as_a_media_failure()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var source = MediaSource.FromSessionFactory(
+            "cancelled.mp4",
+            MediaSourceKind.Stream,
+            async cancellationToken =>
+            {
+                entered.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new UnreachableException();
+            });
+        await using var player = new FFmpegMediaPlayer();
+        var failures = 0;
+        player.MediaFailed += (_, _) => Interlocked.Increment(ref failures);
+        using var cancellation = new CancellationTokenSource();
+
+        var opening = player.OpenAsync(source, cancellationToken: cancellation.Token);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => opening);
+        await Task.Delay(50);
+        Assert.Equal(0, Volatile.Read(ref failures));
+        Assert.Equal(PlaybackState.Closed, player.State);
+    }
+
+    [Fact]
+    public async Task Dispose_is_bounded_when_a_custom_source_ignores_cancellation()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<MediaSourceSession>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var source = MediaSource.FromSessionFactory(
+            "noncooperative.mp4",
+            MediaSourceKind.Stream,
+            _ =>
+            {
+                entered.TrySetResult();
+                return new ValueTask<MediaSourceSession>(release.Task);
+            });
+        var player = new FFmpegMediaPlayer();
+        var opening = player.OpenAsync(source);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var stopwatch = Stopwatch.StartNew();
+        player.Dispose();
+        stopwatch.Stop();
+
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(1),
+            $"Dispose blocked for {stopwatch.Elapsed}.");
+
+        release.TrySetResult(new MediaSourceSession("unused"));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => opening);
+        await player.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(PlaybackState.Disposed, player.State);
+    }
+}

--- a/tests/FFmpegVideoPlayer.Tests/Usings.cs
+++ b/tests/FFmpegVideoPlayer.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/FFmpegVideoPlayer.Tests/YouTubeMediaSourceResolverTests.cs
+++ b/tests/FFmpegVideoPlayer.Tests/YouTubeMediaSourceResolverTests.cs
@@ -1,0 +1,97 @@
+using System.Xml.Linq;
+using FFmpegVideoPlayer.Core;
+using YoutubeExplode.Common;
+using YoutubeExplode.Videos.Streams;
+
+namespace FFmpegVideoPlayer.Tests;
+
+public sealed class YouTubeMediaSourceResolverTests
+{
+    [Fact]
+    public void Selects_highest_h264_mp4_stream_at_or_below_configured_height()
+    {
+        var manifest = new StreamManifest([
+            Video("vp9-2160", Container.WebM, "vp09", 2160, 30, 8_000_000),
+            Video("h264-2160", Container.Mp4, "avc1.640033", 2160, 30, 7_000_000),
+            Video("h264-720", Container.Mp4, "avc1.64001f", 720, 60, 4_000_000),
+            Video("h264-1080", Container.Mp4, "avc1.640028", 1080, 30, 5_000_000),
+        ]);
+
+        var selected = new YouTubeMediaSourceResolver(1080).SelectVideoStream(manifest);
+
+        Assert.NotNull(selected);
+        Assert.Equal("h264-1080", selected.Url);
+    }
+
+    [Fact]
+    public void Dash_manifest_combines_video_and_audio_as_one_ffmpeg_source()
+    {
+        var video = Video("video.mp4", Container.Mp4, "avc1.640028", 1080, 30, 5_000_000);
+        var audio = new AudioOnlyStreamInfo(
+            "audio.m4a",
+            Container.Mp4,
+            new FileSize(1_000_000),
+            new Bitrate(160_000),
+            "mp4a.40.2",
+            null,
+            true);
+
+        var xml = YouTubeMediaSourceResolver.BuildDashManifest(
+            TimeSpan.FromMinutes(3),
+            "video.mp4",
+            video,
+            new SegmentBaseRanges(740, 741, 1288),
+            "audio.mp4",
+            audio,
+            new SegmentBaseRanges(722, 723, 1030));
+        var document = XDocument.Parse(xml);
+        XNamespace dash = "urn:mpeg:dash:schema:mpd:2011";
+
+        var adaptationSets = document.Descendants(dash + "AdaptationSet").ToArray();
+        Assert.Equal(2, adaptationSets.Length);
+        Assert.Contains(adaptationSets, set => (string?)set.Attribute("contentType") == "video");
+        Assert.Contains(adaptationSets, set => (string?)set.Attribute("contentType") == "audio");
+        Assert.Equal(
+            new[] { "video.mp4", "audio.mp4" },
+            document.Descendants(dash + "BaseURL").Select(element => element.Value));
+        Assert.Equal(
+            new[] { "741-1288", "723-1030" },
+            document.Descendants(dash + "SegmentBase").Select(element => (string?)element.Attribute("indexRange")));
+    }
+
+    [Fact]
+    public async Task Finds_top_level_sidx_ranges_without_reading_media_payload()
+    {
+        var bytes = new byte[64];
+        WriteBox(bytes, 0, 24, "ftyp");
+        WriteBox(bytes, 24, 20, "moov");
+        WriteBox(bytes, 44, 20, "sidx");
+        await using var stream = new MemoryStream(bytes, writable: false);
+
+        var ranges = await YouTubeMediaSourceResolver.FindSegmentBaseRangesAsync(stream);
+
+        Assert.Equal(new SegmentBaseRanges(43, 44, 63), ranges);
+    }
+
+    private static VideoOnlyStreamInfo Video(
+        string url,
+        Container container,
+        string codec,
+        int height,
+        int frameRate,
+        long bitrate) =>
+        new(
+            url,
+            container,
+            new FileSize(10_000_000),
+            new Bitrate(bitrate),
+            codec,
+            new VideoQuality(height, frameRate),
+            new Resolution(height * 16 / 9, height));
+
+    private static void WriteBox(byte[] destination, int offset, int size, string type)
+    {
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(destination.AsSpan(offset, 4), (uint)size);
+        System.Text.Encoding.ASCII.GetBytes(type, destination.AsSpan(offset + 4, 4));
+    }
+}


### PR DESCRIPTION
## Summary

- upgrade the standalone control and all projects to Avalonia 12.1.0
- ship Core, OpenTK audio, FFmpeg and OpenAL through one `FFmpegVideoPlayer.Avalonia` 3.0.0 package
- own typed local/HTTP/stream/manifest/YouTube sources, bounded loopback streaming, cancellation, lifecycle and structured errors inside the package
- harden playback teardown, stale-source events, bounded audio backpressure, EOF draining and OpenAL thread ownership
- add CI package-consumer validation, release publishing workflow and third-party license/provenance notices

## Verification

- `dotnet build FFmpegVideoPlayer.Avalonia.sln -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet test tests/FFmpegVideoPlayer.Tests/FFmpegVideoPlayer.Tests.csproj -c Release --no-build --no-restore` — 16/16 passed
- clean NuGet consumer opened a real YouTube source (`1920x804`, audio present)
- clean NuGet consumer played a 220 ms WAV through OpenAL to `PlaybackState.Ended`

NuGet.org publication is wired to GitHub releases and requires the repository secret `NUGET_API_KEY`.
