### PR TITLE
Fix: mp3s with embedded cover art skip real-time playback pacing

### DIFF
--- a/FFmpegVideoPlayer.Core/FFmpegMediaPlayer.cs
+++ b/FFmpegVideoPlayer.Core/FFmpegMediaPlayer.cs
@@ -378,8 +378,20 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
             // Find video and audio streams
             for (int i = 0; i < _formatContext->nb_streams; i++)
             {
-                var codecType = _formatContext->streams[i]->codecpar->codec_type;
-                if (codecType == AVMediaType.AVMEDIA_TYPE_VIDEO && _videoStreamIndex < 0)
+                var stream = _formatContext->streams[i];
+                var codecType = stream->codecpar->codec_type;
+
+                // Embedded cover art (ID3 APIC / MP4 "covr" etc.) is exposed by FFmpeg as a
+                // single-frame AVMEDIA_TYPE_VIDEO stream flagged AV_DISPOSITION_ATTACHED_PIC.
+                // Treating it as real video pulls the player out of the audio-only code path
+                // (WaitForAudioOnlyPlaybackToFinish / UpdateAudioOnlyPositionFromPlaybackClock
+                // both bail out whenever _videoStreamIndex >= 0), which removes all real-time
+                // pacing and lets decode race through the whole file in well under a second.
+                // Most tagged mp3s carry embedded artwork, so skip attached-picture streams
+                // when picking the playback video stream.
+                bool isAttachedPic = (stream->disposition & ffmpeg.AV_DISPOSITION_ATTACHED_PIC) != 0;
+
+                if (codecType == AVMediaType.AVMEDIA_TYPE_VIDEO && !isAttachedPic && _videoStreamIndex < 0)
                 {
                     _videoStreamIndex = i;
                     _logger.Log("FFmpegMediaPlayer", "VideoStreamFound", new { StreamIndex = i });
@@ -388,6 +400,10 @@ public sealed unsafe class FFmpegMediaPlayer : IDisposable
                 {
                     _audioStreamIndex = i;
                     _logger.Log("FFmpegMediaPlayer", "AudioStreamFound", new { StreamIndex = i });
+                }
+                else if (codecType == AVMediaType.AVMEDIA_TYPE_VIDEO && isAttachedPic)
+                {
+                    _logger.Log("FFmpegMediaPlayer", "AttachedPictureStreamSkipped", new { StreamIndex = i });
                 }
             }
 


### PR DESCRIPTION
## Summary

mp3 (and other audio) files with embedded cover art / album art finish playback almost instantly instead of playing for their real duration.

## Root cause

FFmpeg exposes embedded cover art (ID3 `APIC`, MP4 `covr`, etc.) as a second stream: `codec_type=video`, `codec_name=mjpeg`, with the disposition flag `AV_DISPOSITION_ATTACHED_PIC`. In `FFmpegVideoPlayer.Core/FFmpegMediaPlayer.cs`, `Open()`'s stream-selection loop picks up **any** `AVMEDIA_TYPE_VIDEO` stream as `_videoStreamIndex`, with no exclusion for attached-picture streams. That makes `_videoStreamIndex >= 0` true for what is actually an audio-only file.

`WaitForAudioOnlyPlaybackToFinish` and `UpdateAudioOnlyPositionFromPlaybackClock` — both added in 2.9.0 specifically to give audio-only files real-time playback pacing — explicitly bail out whenever `_videoStreamIndex >= 0`. With those disabled, nothing throttles the decode loop to real time, so the file finishes decoding (and fires `EndReached`) almost instantly instead of playing for its actual duration.

This isn't a rare edge case: most commercially tagged mp3 files carry embedded album art, so this affects a large fraction of real-world files despite 2.9.0's stated goal of fixing audio-only playback.

## Fix

Skip streams flagged `AV_DISPOSITION_ATTACHED_PIC` when selecting the playback video stream in `Open()`'s stream-selection loop. Files whose only "video" stream is attached cover art now correctly stay on the audio-only playback path (real-time clock pacing, audio placeholder UI).

## Verification (manual)

No automated test is included — `main` currently has no test infrastructure (no test project, no xunit/nunit/mstest reference anywhere in the tree, and CI only runs `dotnet build`, not `dotnet test`). Adding a full test project felt out of scope for a one-line targeted fix, so instead here's a manual before/after repro against a real 235.18s mp3 with embedded cover art, driven directly through `FFmpegMediaPlayer` (open → `Play()` → sample `Position` every second):

**Before this fix** (unmodified `main`): `EndReached` fired at wall-clock **1.01s** — the entire 235s file "played" in about a second.

**After this fix** (this branch): playback position tracked wall-clock time within **~40ms drift**, sampled every second over a 20s window, with no premature end:
```
t=1.0s   playbackPos=0.99s   drift=-0.03s
t=5.0s   playbackPos=5.01s   drift=-0.02s
t=10.1s  playbackPos=10.05s  drift=+0.00s
t=15.1s  playbackPos=15.03s  drift=-0.04s
t=20.1s  playbackPos=20.07s  drift=-0.02s
Test window elapsed without natural end (expected duration 235.2s).
```

Also confirmed the fix doesn't break the build: `dotnet build FFmpegVideoPlayer.Avalonia.sln -c Release` succeeds with 0 warnings / 0 errors on this branch.

## Notes

- No version bump or `CHANGELOG.md` entry included — leaving that release decision to you.
- Happy to add a regression test if you'd like to bootstrap test infra for this — didn't want to presume CI changes in a first PR.
